### PR TITLE
Refactor S3DIS dataset

### DIFF
--- a/kpconv_torch/cli/__main__.py
+++ b/kpconv_torch/cli/__main__.py
@@ -40,17 +40,28 @@ def kpconv_parser(subparser, reference_func, command, command_description):
         type=valid_dir,
         help="Path of the dataset on the file system",
     )
+    if command == "test":
+        parser.add_argument(
+            "-f",
+            "--filename",
+            type=str,
+            help=(
+                "File on which to predict semantic labels starting from a trained model "
+                "(if None, use the validation split)"
+            ),
+        )
     #   Here you can choose which model you want to use. Here are the possible values :
     #
     #       > 'last_XXX': Automatically retrieve the last trained model on dataset XXX
     #       > 'results/Log_YYYY-MM-DD_HH-MM-SS': Directly provide the path of a trained model
-    parser.add_argument(
-        "-l",
-        "--chosen-log",
-        required=True,
-        type=valid_dir,
-        help="Path of the KPConv log folder on the file system",
-    )
+    if command != "preprocess":
+        parser.add_argument(
+            "-l",
+            "--chosen-log",
+            required=True,
+            type=valid_dir,
+            help="Path of the KPConv log folder on the file system",
+        )
     parser.add_argument(
         "-s",
         "--dataset",

--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -23,7 +23,7 @@ class NPM3DDataset(PointCloudDataset):
     """Class to handle NPM3D dataset."""
 
     def __init__(
-        self, datapath, config, set="training", use_potentials=True, load_data=True
+        self, datapath, config, split="training", use_potentials=True, load_data=True
     ):
         """
         This dataset is small enough to be stored in-memory, so load all point clouds here
@@ -68,7 +68,7 @@ class NPM3DDataset(PointCloudDataset):
         self.config = config
 
         # Training or test set
-        self.set = set
+        self.set = split
 
         # Using potential or random epoch generation
         self.use_potentials = use_potentials

--- a/kpconv_torch/datasets/SemanticKitti.py
+++ b/kpconv_torch/datasets/SemanticKitti.py
@@ -17,7 +17,7 @@ from kpconv_torch.utils.mayavi_visu import KDTree
 class SemanticKittiDataset(PointCloudDataset):
     """Class to handle SemanticKitti dataset."""
 
-    def __init__(self, datapath, config, set="training", balance_classes=True):
+    def __init__(self, datapath, config, split="training", balance_classes=True):
         PointCloudDataset.__init__(self, "SemanticKitti")
 
         ##########################
@@ -31,7 +31,7 @@ class SemanticKittiDataset(PointCloudDataset):
         self.dataset_task = "slam_segmentation"
 
         # Training or test set
-        self.set = set
+        self.set = split
 
         # Get a list of sequences
         if self.set == "training":
@@ -145,7 +145,7 @@ class SemanticKittiDataset(PointCloudDataset):
             self.in_R = config.val_radius
 
         # shared epoch indices and classes (in case we want class balanced sampler)
-        if set == "training":
+        if self.set == "training":
             N = int(np.ceil(config.epoch_steps * self.batch_num * 1.1))
         else:
             N = int(np.ceil(config.validation_size * self.batch_num * 1.1))

--- a/kpconv_torch/datasets/Toronto3D.py
+++ b/kpconv_torch/datasets/Toronto3D.py
@@ -18,7 +18,7 @@ class Toronto3DDataset(PointCloudDataset):
     """Class to handle Toronto3D dataset."""
 
     def __init__(
-        self, datapath, config, set="training", use_potentials=True, load_data=True
+        self, datapath, config, split="training", use_potentials=True, load_data=True
     ):
         """
         This dataset is small enough to be stored in-memory, so load all point clouds here
@@ -62,7 +62,7 @@ class Toronto3DDataset(PointCloudDataset):
         self.config = config
 
         # Training or test set
-        self.set = set
+        self.set = split
 
         # Using potential or random epoch generation
         self.use_potentials = use_potentials

--- a/kpconv_torch/preprocess.py
+++ b/kpconv_torch/preprocess.py
@@ -1,18 +1,21 @@
-import os
-
 from kpconv_torch.datasets.ModelNet40 import (
+    ModelNet40Config,
     ModelNet40Dataset,
 )
 from kpconv_torch.datasets.NPM3D import (
+    NPM3DConfig,
     NPM3DDataset,
 )
 from kpconv_torch.datasets.S3DIS import (
+    S3DISConfig,
     S3DISDataset,
 )
 from kpconv_torch.datasets.SemanticKitti import (
+    SemanticKittiConfig,
     SemanticKittiDataset,
 )
 from kpconv_torch.datasets.Toronto3D import (
+    Toronto3DConfig,
     Toronto3DDataset,
 )
 from kpconv_torch.utils.config import Config
@@ -20,23 +23,26 @@ from kpconv_torch.utils.config import Config
 
 def main(args):
 
-    ############################
-    # Initialize the environment
-    ############################
-    # Set which gpu is going to be used
-    GPU_ID = "0"
+    # ############################
+    # # Initialize the environment
+    # ############################
+    # # Set which gpu is going to be used
+    # GPU_ID = "0"
 
-    # Set GPU visible device
-    os.environ["CUDA_VISIBLE_DEVICES"] = GPU_ID
+    # # Set GPU visible device
+    # os.environ["CUDA_VISIBLE_DEVICES"] = GPU_ID
 
     # Initialize configuration class
-    config = Config()
-    config.load(args.chosen_log)
-    if config.dataset != args.dataset:
-        raise ValueError(
-            f"Config dataset ({config.dataset}) "
-            f"does not match provided dataset ({args.dataset})."
-        )
+    if args.dataset == "ModelNet40":
+        config = ModelNet40Config()
+    if args.dataset == "NPM3D":
+        config = NPM3DConfig()
+    if args.dataset == "S3DIS":
+        config = S3DISConfig()
+    if args.dataset == "SemanticKitti":
+        config = SemanticKittiConfig()
+    elif args.dataset == "Toronto3D":
+        config = Toronto3DConfig()
 
     ##################################
     # Change model parameters for test
@@ -62,22 +68,24 @@ def main(args):
         _ = ModelNet40Dataset(args.datapath, config, train=True)
         _ = ModelNet40Dataset(args.datapath, config, train=False)
     elif config.dataset == "NPM3D":
-        _ = NPM3DDataset(args.datapath, config, set="training", use_potentials=True)
-        _ = NPM3DDataset(args.datapath, config, set="validation", use_potentials=True)
+        _ = NPM3DDataset(args.datapath, config, split="training", use_potentials=True)
+        _ = NPM3DDataset(args.datapath, config, split="validation", use_potentials=True)
     elif config.dataset == "S3DIS":
-        _ = S3DISDataset(args.datapath, config, set="training", use_potentials=True)
-        _ = S3DISDataset(args.datapath, config, set="validation", use_potentials=True)
+        _ = S3DISDataset(args.datapath, config, split="training", use_potentials=True)
+        _ = S3DISDataset(args.datapath, config, split="validation", use_potentials=True)
     elif config.dataset == "SemanticKitti":
         _ = SemanticKittiDataset(
-            args.datapath, config, set="training", balance_classes=True
+            args.datapath, config, split="training", balance_classes=True
         )
         _ = SemanticKittiDataset(
-            args.datapath, config, set="validation", balance_classes=False
+            args.datapath, config, split="validation", balance_classes=False
         )
     elif config.dataset == "Toronto3D":
-        _ = Toronto3DDataset(args.datapath, config, set="training", use_potentials=True)
         _ = Toronto3DDataset(
-            args.datapath, config, set="validation", use_potentials=True
+            args.datapath, config, split="training", use_potentials=True
+        )
+        _ = Toronto3DDataset(
+            args.datapath, config, split="validation", use_potentials=True
         )
     else:
         raise ValueError("Unsupported dataset : " + config.dataset)

--- a/kpconv_torch/test.py
+++ b/kpconv_torch/test.py
@@ -122,10 +122,7 @@ def main(args):
     print("Data Preparation")
     print("****************")
 
-    if on_val:
-        set = "validation"
-    else:
-        set = "test"
+    split = "validation" if on_val else "test"
 
     # Initiate dataset
     if config.dataset == "ModelNet40":
@@ -134,19 +131,23 @@ def main(args):
         collate_fn = ModelNet40Collate
     elif config.dataset == "S3DIS":
         test_dataset = S3DISDataset(
-            args.datapath, config, set="validation", use_potentials=True
+            args.datapath,
+            config,
+            split="validation" if args.filename is None else "test",
+            use_potentials=True,
+            infered_file=args.filename,
         )
         test_sampler = S3DISSampler(test_dataset)
         collate_fn = S3DISCollate
     elif config.dataset == "Toronto3D":
         test_dataset = Toronto3DDataset(
-            args.datapath, config, set="test", use_potentials=True
+            args.datapath, config, split="test", use_potentials=True
         )
         test_sampler = Toronto3DSampler(test_dataset)
         collate_fn = Toronto3DCollate
     elif config.dataset == "SemanticKitti":
         test_dataset = SemanticKittiDataset(
-            args.datapath, config, set=set, balance_classes=False
+            args.datapath, config, split=split, balance_classes=False
         )
         test_sampler = SemanticKittiSampler(test_dataset)
         collate_fn = SemanticKittiCollate

--- a/kpconv_torch/test.py
+++ b/kpconv_torch/test.py
@@ -74,7 +74,7 @@ def main(args):
     on_val = True
 
     # Deal with 'last_XXXXXX' choices
-    chosen_log = model_choice(args.chosen_log)
+    chosen_log = str(model_choice(args.chosen_log))
 
     ############################
     # Initialize the environment

--- a/kpconv_torch/train.py
+++ b/kpconv_torch/train.py
@@ -110,40 +110,40 @@ def main(args):
         collate_fn = ModelNet40Collate
     elif config.dataset == "NPM3D":
         training_dataset = NPM3DDataset(
-            args.datapath, config, set="training", use_potentials=True
+            args.datapath, config, split="training", use_potentials=True
         )
         test_dataset = NPM3DDataset(
-            args.datapath, config, set="validation", use_potentials=True
+            args.datapath, config, split="validation", use_potentials=True
         )
         training_sampler = NPM3DSampler(training_dataset)
         test_sampler = NPM3DSampler(test_dataset)
         collate_fn = NPM3DCollate
     elif config.dataset == "S3DIS":
         training_dataset = S3DISDataset(
-            args.datapath, config, set="training", use_potentials=True
+            args.datapath, config, split="training", use_potentials=True
         )
         test_dataset = S3DISDataset(
-            args.datapath, config, set="validation", use_potentials=True
+            args.datapath, config, split="validation", use_potentials=True
         )
         training_sampler = S3DISSampler(training_dataset)
         test_sampler = S3DISSampler(test_dataset)
         collate_fn = S3DISCollate
     elif config.dataset == "SemanticKitti":
         training_dataset = SemanticKittiDataset(
-            args.datapath, config, set="training", balance_classes=True
+            args.datapath, config, split="training", balance_classes=True
         )
         test_dataset = SemanticKittiDataset(
-            args.datapath, config, set="validation", balance_classes=False
+            args.datapath, config, split="validation", balance_classes=False
         )
         training_sampler = SemanticKittiSampler(training_dataset)
         test_sampler = SemanticKittiSampler(test_dataset)
         collate_fn = SemanticKittiCollate
     elif config.dataset == "Toronto3D":
         training_dataset = Toronto3DDataset(
-            args.datapath, config, set="training", use_potentials=True
+            args.datapath, config, split="training", use_potentials=True
         )
         test_dataset = Toronto3DDataset(
-            args.datapath, config, set="validation", use_potentials=True
+            args.datapath, config, split="validation", use_potentials=True
         )
         training_sampler = Toronto3DSampler(training_dataset)
         test_sampler = Toronto3DSampler(test_dataset)

--- a/kpconv_torch/utils/tester.py
+++ b/kpconv_torch/utils/tester.py
@@ -286,8 +286,8 @@ class ModelTester:
             # Update minimum od potentials
             new_min = torch.min(test_loader.dataset.min_potentials)
             print(
-                "Test epoch {:d}, end. Min potential = {:.1f}".format(
-                    test_epoch, new_min
+                "Test epoch {:d}, end. Min potential = {:.1f} (last: {:.1f})".format(
+                    test_epoch, new_min, last_min
                 )
             )
             # print([np.mean(pots) for pots in test_loader.dataset.potentials])

--- a/kpconv_torch/utils/trainer.py
+++ b/kpconv_torch/utils/trainer.py
@@ -407,7 +407,8 @@ class ModelTrainer:
         softmax = torch.nn.Softmax(1)
 
         # Do not validate if dataset has no validation cloud
-        if val_loader.dataset.validation_split not in val_loader.dataset.all_splits:
+        # if val_loader.dataset.validation_split not in val_loader.dataset.all_splits:
+        if len(val_loader.dataset.validation_cloud_names) == 0:
             return
 
         # Number of classes including ignored labels

--- a/kpconv_torch/visualize.py
+++ b/kpconv_torch/visualize.py
@@ -124,7 +124,7 @@ def main(args):
         collate_fn = ModelNet40Collate
     elif config.dataset == "S3DIS":
         test_dataset = S3DISDataset(
-            args.datapath, config, set="validation", use_potentials=True
+            args.datapath, config, split="validation", use_potentials=True
         )
         test_sampler = S3DISSampler(test_dataset)
         collate_fn = S3DISCollate


### PR DESCRIPTION
Major refactoring of S3DIS dataset, in order to make inference on unknown data (a file which is not directly picked from the S3DIS data).

This change is allowed through the introduction of a `infered_file` parameter in the CLI. The attributes of the dataset class have been modified as well to better model the situation ("internal" or "external" inference).

Small bonus:

- 'set' replaced by 'split' (Python reserved word)
- minor print modification during inference (last min potential, for each epoch)
- config.saving_path as a string (instead of a Pathlib.path)
