### PR TITLE
ci: add linting operations through Github actions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-ignore = B028,E203,E501,PIE786,SIM115,W503
+max-line-length = 88
+ignore = B028,E203,E501,E704,PIE786,SIM115,W503
 exclude =
     build/,
     *venv/,

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 ignore = B028,E203,E501,E704,PIE786,SIM115,W503
+select = C,E,F,W,B,B950
 exclude =
     build/,
     *venv/,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pylint flake8 black
+          python -m pip install -r requirements-dev.txt
 
       - name: Analysing the code with pylint
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: "Lint"
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - "docs/**"
+  push:
+    branches: [master]
+    paths-ignore:
+      - "docs/**"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  lintest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Get source code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pylint flake8 black
+
+      - name: Analysing the code with pylint
+        run: |
+          pylint $(git ls-files '*.py') --fail-under 8
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Check code with black
+        run: |
+          black .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-        args: [--target-version=py38]
+        args: [--target-version=py38,--line-length=100]
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,16 +26,17 @@ repos:
         args: [--target-version=py38]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies:
+          - flake8-builtins>=2.1.0
           - flake8-import-order==0.18.2
-          - flake8-bugbear==23.1.20
-          - flake8-comprehensions==3.10.1
-          - flake8-simplify==0.19.3
-          - flake8-builtins==2.1.0
-          - flake8-pie==0.15.0
+          - flake8-bugbear>=23.12
+          - flake8-comprehensions>=3.10.1
+          - flake8-isort>=6
+          - flake8-simplify>=0.19.3
+          - flake8-eradicate>=1
         args:
           - --per-file-ignores=kpconv_torch/utils/visualizer.py:B023
 

--- a/kpconv_torch/datasets/SemanticKitti.py
+++ b/kpconv_torch/datasets/SemanticKitti.py
@@ -859,14 +859,18 @@ class SemanticKittiSampler(Sampler):
                         )
 
                     else:
-                        error_message = "\nIt seems there is a problem with the class statistics of your dataset, saved in the variable dataset.class_frames.\n"
-                        error_message += "Here are the current statistics:\n"
+                        error_message = "\nIt seems there is a problem with the class statistics "
+                        error_message += "of your dataset, saved in the variable "
+                        error_message += "dataset.class_frames.\nHere are the current statistics:\n"
                         error_message += "{:>15s} {:>15s}\n".format(
                             "Class", "# of frames"
                         )
                         for iii, _ in enumerate(self.dataset.label_values):
-                            error_message += f"{self.dataset.label_names[iii]:>15s} {len(self.dataset.class_frames[iii]):>15d}\n"
-                        error_message += "\nThis error is raised if one of the classes is not ignored and does not appear in any of the frames of the dataset.\n"
+                            error_message += f"{self.dataset.label_names[iii]:>15s} "
+                            error_message += "{len(self.dataset.class_frames[iii]):>15d}\n"
+                        error_message += "\nThis error is raised if one of the classes "
+                        error_message += "is not ignored and does not appear "
+                        error_message += "in any of the frames of the dataset.\n"
                         raise ValueError(error_message)
 
             # Stack the chosen indices of all classes

--- a/kpconv_torch/utils/ply.py
+++ b/kpconv_torch/utils/ply.py
@@ -223,7 +223,7 @@ def write_ply(filename, field_list, field_names, triangular_faces=None):
     # Format list input to the right form
     field_list = (
         list(field_list)
-        if (type(field_list) == list or type(field_list) == tuple)
+        if (isinstance(field_list, list) or isinstance(field_list, tuple))
         else list((field_list,))  # noqa: C410
     )
     for i, field in enumerate(field_list):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,14 @@
-pre-commit
 -r requirements.txt
+
+pre-commit>=3,<4
+black>=22,<23
+flake8>=6,<8
+flake8-bugbear>=23.12
+flake8-builtins>=2.1
+flake8-eradicate>=1
+flake8-isort>=6
+flake8-comprehensions>=3.10.1
+flake8-simplify>=0.19.3
+flake8-pie>=0.15.0
+pylint>=3,<4
+pytest>=7,<8


### PR DESCRIPTION
Initialize a CI with a first job of syntaxing checkings.

The CI uses `pylint`, `flake8` and `black`.

- `pylint` is set as OK if the source code is rated at least 8/10.
- `flake8` failures are set only for some syntax error codes for now, as there are a lot of minor details to fix. [For now, the result is](https://github.com/Guts/mkdocs-rss-plugin/blob/main/.github/workflows/lint-and-tests.yml) :  60 B023 errors (Function definition does not bind loop variable), 46 C901 (too much complexity), 94 E800 (Found commented out code).

Is the same move, an update on linting dependencies have been done (some `flake8` extensions have been added, and dependency versions have been checked).
