### PR TITLE
Store predicted values in a 'classification' ply properties

### DIFF
--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -704,12 +704,12 @@ class NPM3DDataset(PointCloudDataset):
                 write_ply(join(ply_path, cloud_name + ".ply"), cloud_points, field_names)
 
             else:
-                labels = original_ply["class"]
+                labels = original_ply["classification"]
                 labels = labels.astype(np.int32)
                 labels = labels.reshape(len(labels), 1)
 
                 # Save as ply
-                field_names = ["x", "y", "z", "class"]
+                field_names = ["x", "y", "z", "classification"]
                 write_ply(
                     join(ply_path, cloud_name + ".ply"),
                     [cloud_points, labels],
@@ -752,7 +752,7 @@ class NPM3DDataset(PointCloudDataset):
                 # read ply with data
                 data = read_ply(sub_ply_file)
                 # sub_colors = np.vstack((data['red'], data['green'], data['blue'])).T
-                sub_labels = data["class"]
+                sub_labels = data["classification"]
 
                 # Read pkl with search tree
                 with open(KDTree_file, "rb") as f:
@@ -770,7 +770,7 @@ class NPM3DDataset(PointCloudDataset):
                 if self.set == "test":
                     labels = np.zeros((data.shape[0],), dtype=np.int32)
                 else:
-                    labels = data["class"]
+                    labels = data["classification"]
 
                 # Subsample cloud
                 sub_points, sub_labels = grid_subsampling(points, labels=labels, sampleDl=dl)
@@ -789,7 +789,7 @@ class NPM3DDataset(PointCloudDataset):
                     pickle.dump(search_tree, f)
 
                 # Save ply
-                write_ply(sub_ply_file, [sub_points, sub_labels], ["x", "y", "z", "class"])
+                write_ply(sub_ply_file, [sub_points, sub_labels], ["x", "y", "z", "classification"])
 
             # Fill data containers
             self.input_trees += [search_tree]
@@ -879,7 +879,7 @@ class NPM3DDataset(PointCloudDataset):
                     if self.set == "test":
                         labels = np.zeros((data.shape[0],), dtype=np.int32)
                     else:
-                        labels = data["class"]
+                        labels = data["classification"]
 
                     # Compute projection inds
                     idxs = self.input_trees[i].query(points, return_distance=False)

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -667,7 +667,7 @@ class S3DISDataset(PointCloudDataset):
             write_ply(
                 cloud_file,
                 (cloud_points, cloud_colors, cloud_classes),
-                ["x", "y", "z", "red", "green", "blue", "class"],
+                ["x", "y", "z", "red", "green", "blue", "classification"],
             )
 
         print(f"Done in {time.time() - t0:.1f}s")
@@ -730,7 +730,7 @@ class S3DISDataset(PointCloudDataset):
             write_ply(
                 sub_ply_file,
                 [sub_points, sub_colors, sub_labels],
-                ["x", "y", "z", "red", "green", "blue", "class"],
+                ["x", "y", "z", "red", "green", "blue", "classification"],
             )
 
         # Fill data containers
@@ -873,7 +873,7 @@ class S3DISDataset(PointCloudDataset):
             data = read_ply(filename)
             points = np.vstack((data["x"], data["y"], data["z"])).T
             colors = np.vstack((data["red"], data["green"], data["blue"])).T
-            labels = data["class"]
+            labels = data["classification"]
         elif file_extension == "xyz":
             data = np.loadtxt(filename, delimiter=" ")
             points = data[:, :3].astype(np.float32)

--- a/kpconv_torch/plot_convergence.py
+++ b/kpconv_torch/plot_convergence.py
@@ -145,7 +145,7 @@ def load_snap_clouds(path, dataset, only_last=False):
             for f in listdir_str(cloud_folder):
                 if f.endswith(".ply") and not f.endswith("sub.ply"):
                     data = read_ply(join(cloud_folder, f))
-                    labels = data["class"]
+                    labels = data["classification"]
                     preds = data["preds"]
                     Confs[c_i] += fast_confusion(labels, preds, dataset.label_values).astype(
                         np.int32

--- a/kpconv_torch/utils/trainer.py
+++ b/kpconv_torch/utils/trainer.py
@@ -642,7 +642,9 @@ class ModelTrainer:
 
                 # Save file
                 labels = val_loader.dataset.validation_labels[i].astype(np.int32)
-                write_ply(val_name, [points, preds, labels], ["x", "y", "z", "preds", "class"])
+                write_ply(
+                    val_name, [points, preds, labels], ["x", "y", "z", "preds", "classification"]
+                )
 
         # Display timings
         t7 = time.time()


### PR DESCRIPTION
In the default behavior, the properties is named `class`. This PR proposes to name it `classification` for two main reason:

- choose a clearer name (`class` generates a mix-up with Python classes).
- be consistent with other tools like [py3dtiles](https://gitlab.com/py3dtiles/py3dtiles/-/blob/main/py3dtiles/reader/ply_reader.py?ref_type=heads#L119).