### PR TITLE
Fix test save path

### DIFF
--- a/kpconv_torch/test.py
+++ b/kpconv_torch/test.py
@@ -26,7 +26,7 @@ from kpconv_torch.datasets.Toronto3D import (
 )
 from kpconv_torch.models.architectures import KPCNN, KPFCNN
 from kpconv_torch.utils.config import Config
-from kpconv_torch.utils.tester import ModelTester
+from kpconv_torch.utils.tester import ModelTester, get_test_save_path
 
 
 def model_choice(chosen_log):
@@ -219,12 +219,13 @@ def main(args):
     print("\nStart test")
     print("**********\n")
 
+    output_path = get_test_save_path(args.filename, chosen_log)
     # Testing
     if config.dataset_task == "classification":
-        tester.classification_test(net, test_loader, config)
+        tester.classification_test(net, test_loader, config, output_path)
     elif config.dataset_task == "cloud_segmentation":
-        tester.cloud_segmentation_test(net, test_loader, config)
+        tester.cloud_segmentation_test(net, test_loader, config, output_path)
     elif config.dataset_task == "slam_segmentation":
-        tester.slam_segmentation_test(net, test_loader, config)
+        tester.slam_segmentation_test(net, test_loader, config, output_path)
     else:
         raise ValueError("Unsupported dataset_task for testing: " + config.dataset_task)

--- a/kpconv_torch/utils/tester.py
+++ b/kpconv_torch/utils/tester.py
@@ -46,7 +46,7 @@ class ModelTester:
 
         return
 
-    def classification_test(self, net, test_loader, config, num_votes=100, debug=False):
+    def classification_test(self, net, test_loader, config, test_path, num_votes=100, debug=False):
 
         ############
         # Initialize
@@ -146,7 +146,9 @@ class ModelTester:
 
         return
 
-    def cloud_segmentation_test(self, net, test_loader, config, num_votes=100, debug=False):
+    def cloud_segmentation_test(
+        self, net, test_loader, config, test_path, num_votes=100, debug=False
+    ):
         """
         Test method for cloud segmentation models
         """
@@ -174,7 +176,6 @@ class ModelTester:
 
         # Test saving path
         if config.saving:
-            test_path = get_test_save_path()
             if not exists(test_path):
                 makedirs(test_path)
             if not exists(join(test_path, "predictions")):
@@ -484,7 +485,9 @@ class ModelTester:
 
         return
 
-    def slam_segmentation_test(self, net, test_loader, config, num_votes=100, debug=True):
+    def slam_segmentation_test(
+        self, net, test_loader, config, test_path, num_votes=100, debug=True
+    ):
         """
         Test method for slam segmentation models
         """
@@ -503,10 +506,8 @@ class ModelTester:
         nc_model = net.C
 
         # Test saving path
-        test_path = None
         report_path = None
         if config.saving:
-            test_path = get_test_save_path()
             if not exists(test_path):
                 makedirs(test_path)
             report_path = join(test_path, "reports")


### PR DESCRIPTION
#22 introduced a bug for the `kpconv test` command.

`get_test_save_path` needs two parameters, but the calls to this function are parameter-less.

I suggest not to exploit it in `utils/tester.py` in order to avoid passing `args` to `ModelTester`: this object only needs an output path.