### PR TITLE
Run test on CPU

### DIFF
--- a/kpconv_torch/utils/tester.py
+++ b/kpconv_torch/utils/tester.py
@@ -38,7 +38,7 @@ class ModelTester:
         ##########################
         # Load previous checkpoint
         ##########################
-        checkpoint = torch.load(chkp_path)
+        checkpoint = torch.load(chkp_path, map_location=self.device)
         net.load_state_dict(checkpoint["model_state_dict"])
         self.epoch = checkpoint["epoch"]
         net.eval()
@@ -240,7 +240,8 @@ class ModelTester:
                 lengths = batch.lengths[0].cpu().numpy()
                 in_inds = batch.input_inds.cpu().numpy()
                 cloud_inds = batch.cloud_inds.cpu().numpy()
-                torch.cuda.synchronize(self.device)
+                if "cuda" in self.device.type:
+                    torch.cuda.synchronize(self.device)
 
                 # Get predictions and labels per instance
                 # ***************************************
@@ -562,7 +563,8 @@ class ModelTester:
                 r_inds_list = batch.reproj_inds
                 r_mask_list = batch.reproj_masks
                 labels_list = batch.val_labels
-                torch.cuda.synchronize(self.device)
+                if "cuda" in self.device.type:
+                    torch.cuda.synchronize(self.device)
 
                 t += [time.time()]
 


### PR DESCRIPTION
Some fixes in order to run `kpconv test` with the CPU.

Fixes #31 