### PR TITLE
Fix super constructor

### DIFF
--- a/kpconv_torch/datasets/ModelNet40.py
+++ b/kpconv_torch/datasets/ModelNet40.py
@@ -30,7 +30,6 @@ class ModelNet40Dataset(PointCloudDataset):
         This dataset is small enough to be stored in-memory, so load all point clouds here
         """
         super().__init__(
-            self,
             config=config,
             datapath=datapath,
             dataset="ModelNet40",

--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -36,7 +36,6 @@ class NPM3DDataset(PointCloudDataset):
         This dataset is small enough to be stored in-memory, so load all point clouds here
         """
         super().__init__(
-            self,
             config=config,
             datapath=datapath,
             dataset="NPM3D",

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -36,7 +36,6 @@ class S3DISDataset(PointCloudDataset):
         This dataset is small enough to be stored in-memory, so load all point clouds here
         """
         super().__init__(
-            self,
             config=config,
             datapath=datapath,
             dataset="S3DIS",

--- a/kpconv_torch/datasets/SemanticKitti.py
+++ b/kpconv_torch/datasets/SemanticKitti.py
@@ -29,7 +29,6 @@ class SemanticKittiDataset(PointCloudDataset):
         split="training",
     ):
         super().__init__(
-            self,
             config=config,
             datapath=datapath,
             dataset="SemanticKitti",

--- a/kpconv_torch/datasets/Toronto3D.py
+++ b/kpconv_torch/datasets/Toronto3D.py
@@ -36,7 +36,6 @@ class Toronto3DDataset(PointCloudDataset):
         This dataset is small enough to be stored in-memory, so load all point clouds here
         """
         super().__init__(
-            self,
             config=config,
             datapath=datapath,
             dataset="Toronto3D",


### PR DESCRIPTION
Calls to `super().__init__` do not need `self`. (Fix after #29)