### PR TITLE
Remove command argument

### DIFF
--- a/kpconv_torch/datasets/ModelNet40.py
+++ b/kpconv_torch/datasets/ModelNet40.py
@@ -17,7 +17,6 @@ class ModelNet40Dataset(PointCloudDataset):
 
     def __init__(
         self,
-        command,
         config,
         datapath,
         chosen_log=None,

--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -22,7 +22,6 @@ class NPM3DDataset(PointCloudDataset):
 
     def __init__(
         self,
-        command,
         config,
         datapath,
         chosen_log=None,
@@ -118,7 +117,7 @@ class NPM3DDataset(PointCloudDataset):
         ###################
         # Prepare ply files
         ###################
-        if infered_file is None and (command != "preprocess"):
+        if infered_file is None:
             self.prepare_NPM3D_ply()
 
         ################

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -22,7 +22,6 @@ class S3DISDataset(PointCloudDataset):
 
     def __init__(
         self,
-        command,
         config,
         datapath,
         chosen_log=None,
@@ -124,7 +123,7 @@ class S3DISDataset(PointCloudDataset):
         ###################
         # Prepare ply files
         ###################
-        if infered_file is None and (command != "preprocess"):
+        if infered_file is None:
             self.prepare_S3DIS_ply()
 
         # Stop data is not needed

--- a/kpconv_torch/datasets/Toronto3D.py
+++ b/kpconv_torch/datasets/Toronto3D.py
@@ -22,7 +22,6 @@ class Toronto3DDataset(PointCloudDataset):
 
     def __init__(
         self,
-        command,
         config,
         datapath,
         chosen_log=None,
@@ -111,7 +110,7 @@ class Toronto3DDataset(PointCloudDataset):
         ###################
         # Prepare ply files
         ###################
-        if infered_file is None and (command != "preprocess"):
+        if infered_file is None:
             self.prepare_Toronto3D_ply()
 
         ################

--- a/kpconv_torch/plot_convergence.py
+++ b/kpconv_torch/plot_convergence.py
@@ -607,7 +607,6 @@ def main(args):
     elif config.dataset_task == "cloud_segmentation":
         if config.dataset.startswith("S3DIS"):
             dataset = S3DISDataset(
-                command=args.command,
                 config=config,
                 datapath=args.datapath,
                 load_data=False,

--- a/kpconv_torch/preprocess.py
+++ b/kpconv_torch/preprocess.py
@@ -56,22 +56,16 @@ def main(args):
 
     # Initialize datasets and samplers
     if config.dataset == "ModelNet40":
-        _ = ModelNet40Dataset(
-            command=args.command, config=config, datapath=args.datapath, train=True
-        )
-        _ = ModelNet40Dataset(
-            command=args.command, config=config, datapath=args.datapath, train=False
-        )
+        _ = ModelNet40Dataset(config=config, datapath=args.datapath, train=True)
+        _ = ModelNet40Dataset(config=config, datapath=args.datapath, train=False)
     elif config.dataset == "NPM3D":
         _ = NPM3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="training",
             use_potentials=True,
         )
         _ = NPM3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="validation",
@@ -79,14 +73,12 @@ def main(args):
         )
     elif config.dataset == "S3DIS":
         _ = S3DISDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="training",
             use_potentials=True,
         )
         _ = S3DISDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="validation",
@@ -94,14 +86,12 @@ def main(args):
         )
     elif config.dataset == "SemanticKitti":
         _ = SemanticKittiDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="training",
             balance_classes=True,
         )
         _ = SemanticKittiDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="validation",
@@ -109,14 +99,12 @@ def main(args):
         )
     elif config.dataset == "Toronto3D":
         _ = Toronto3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="training",
             use_potentials=True,
         )
         _ = Toronto3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="validation",

--- a/kpconv_torch/test.py
+++ b/kpconv_torch/test.py
@@ -118,7 +118,6 @@ def main(args):
     # Initiate dataset
     if config.dataset == "ModelNet40":
         test_dataset = ModelNet40Dataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -133,7 +132,6 @@ def main(args):
         collate_fn = ModelNet40Collate
     elif config.dataset == "S3DIS":
         test_dataset = S3DISDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -149,7 +147,6 @@ def main(args):
         collate_fn = S3DISCollate
     elif config.dataset == "Toronto3D":
         test_dataset = Toronto3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -165,7 +162,6 @@ def main(args):
         collate_fn = Toronto3DCollate
     elif config.dataset == "SemanticKitti":
         test_dataset = SemanticKittiDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,

--- a/kpconv_torch/train.py
+++ b/kpconv_torch/train.py
@@ -89,7 +89,6 @@ def main(args):
     # Initialize datasets and samplers
     if config.dataset == "ModelNet40":
         training_dataset = ModelNet40Dataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -97,7 +96,6 @@ def main(args):
             train=True,
         )
         test_dataset = ModelNet40Dataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -119,7 +117,6 @@ def main(args):
         collate_fn = ModelNet40Collate
     elif config.dataset == "NPM3D":
         training_dataset = NPM3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -128,7 +125,6 @@ def main(args):
             use_potentials=True,
         )
         test_dataset = NPM3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -149,7 +145,6 @@ def main(args):
         collate_fn = NPM3DCollate
     elif config.dataset == "S3DIS":
         training_dataset = S3DISDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -158,7 +153,6 @@ def main(args):
             use_potentials=True,
         )
         test_dataset = S3DISDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -179,7 +173,6 @@ def main(args):
         collate_fn = S3DISCollate
     elif config.dataset == "SemanticKitti":
         training_dataset = SemanticKittiDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -188,7 +181,6 @@ def main(args):
             balance_classes=True,
         )
         test_dataset = SemanticKittiDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -209,7 +201,6 @@ def main(args):
         collate_fn = SemanticKittiCollate
     elif config.dataset == "Toronto3D":
         training_dataset = Toronto3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
@@ -218,7 +209,6 @@ def main(args):
             use_potentials=True,
         )
         test_dataset = Toronto3DDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,

--- a/kpconv_torch/visualize.py
+++ b/kpconv_torch/visualize.py
@@ -115,14 +115,11 @@ def main(args):
 
     # Initiate dataset
     if config.dataset.startswith("ModelNet40"):
-        test_dataset = ModelNet40Dataset(
-            command=args.command, config=config, datapath=args.datapath, train=False
-        )
+        test_dataset = ModelNet40Dataset(config=config, datapath=args.datapath, train=False)
         test_sampler = ModelNet40Sampler(test_dataset)
         collate_fn = ModelNet40Collate
     elif config.dataset == "S3DIS":
         test_dataset = S3DISDataset(
-            command=args.command,
             config=config,
             datapath=args.datapath,
             split="validation",


### PR DESCRIPTION
Fix #29: args.command is useless in dataset: after #29 it prevents preparing PLY file if equals to `preprocess`. But that's counterintuitive: preprocess was designed in this purpose. Then we remove this condition, and `command` parameter in each dataset constructor.