### PR TITLE
Fix paths used by preprocessing

### DIFF
--- a/kpconv_torch/datasets/ModelNet40.py
+++ b/kpconv_torch/datasets/ModelNet40.py
@@ -21,7 +21,6 @@ class ModelNet40Dataset(PointCloudDataset):
         datapath,
         chosen_log=None,
         infered_file=None,
-        output_dir=None,
         orient_correction=True,
         split="training",
     ):
@@ -34,7 +33,6 @@ class ModelNet40Dataset(PointCloudDataset):
             dataset="ModelNet40",
             chosen_log=chosen_log,
             infered_file=infered_file,
-            output_dir=output_dir,
             split=split,
         )
 

--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -26,7 +26,6 @@ class NPM3DDataset(PointCloudDataset):
         datapath,
         chosen_log=None,
         infered_file=None,
-        output_dir=None,
         use_potentials=True,
         load_data=True,
         split="training",
@@ -40,7 +39,6 @@ class NPM3DDataset(PointCloudDataset):
             dataset="NPM3D",
             chosen_log=chosen_log,
             infered_file=infered_file,
-            output_dir=output_dir,
             split=split,
         )
 

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -26,7 +26,6 @@ class S3DISDataset(PointCloudDataset):
         datapath,
         chosen_log=None,
         infered_file=None,
-        output_dir=None,
         use_potentials=True,
         load_data=True,
         split="training",
@@ -40,7 +39,6 @@ class S3DISDataset(PointCloudDataset):
             dataset="S3DIS",
             chosen_log=chosen_log,
             infered_file=infered_file,
-            output_dir=output_dir,
             split=split,
         )
 
@@ -594,7 +592,7 @@ class S3DISDataset(PointCloudDataset):
 
         for cloud_name in self.cloud_names:
             # Pass if the cloud has already been computed
-            cloud_file = join(self.train_save_path, cloud_name + ".ply")
+            cloud_file = join(self.train_files_path, cloud_name + ".ply")
             if exists(cloud_file):
                 print(f"{cloud_file} does already exist.")
                 continue

--- a/kpconv_torch/datasets/SemanticKitti.py
+++ b/kpconv_torch/datasets/SemanticKitti.py
@@ -24,7 +24,6 @@ class SemanticKittiDataset(PointCloudDataset):
         datapath,
         chosen_log=None,
         infered_file=None,
-        output_dir=None,
         balance_classes=True,
         split="training",
     ):
@@ -34,7 +33,6 @@ class SemanticKittiDataset(PointCloudDataset):
             dataset="SemanticKitti",
             chosen_log=chosen_log,
             infered_file=infered_file,
-            output_dir=output_dir,
             split=split,
         )
 

--- a/kpconv_torch/datasets/Toronto3D.py
+++ b/kpconv_torch/datasets/Toronto3D.py
@@ -26,7 +26,6 @@ class Toronto3DDataset(PointCloudDataset):
         datapath,
         chosen_log=None,
         infered_file=None,
-        output_dir=None,
         use_potentials=True,
         load_data=True,
         split="training",
@@ -40,7 +39,6 @@ class Toronto3DDataset(PointCloudDataset):
             dataset="Toronto3D",
             chosen_log=chosen_log,
             infered_file=infered_file,
-            output_dir=output_dir,
             split=split,
         )
 

--- a/kpconv_torch/datasets/common.py
+++ b/kpconv_torch/datasets/common.py
@@ -6,7 +6,6 @@ import cpp_wrappers.cpp_subsampling.grid_subsampling as cpp_subsampling
 from kpconv_torch.kernels.kernel_points import create_3D_rotations
 from kpconv_torch.utils.mayavi_visu import show_ModelNet_examples
 from kpconv_torch.utils.tester import get_test_save_path
-from kpconv_torch.utils.trainer import get_train_save_path
 
 
 def grid_subsampling(points, features=None, labels=None, sampleDl=0.1, verbose=0):
@@ -198,7 +197,6 @@ class PointCloudDataset(Dataset):
         dataset,
         chosen_log=None,
         infered_file=None,
-        output_dir=None,
         split="training",
     ):
         """
@@ -228,7 +226,6 @@ class PointCloudDataset(Dataset):
         if split not in ["training", "validation", "test", "ERF", "all"]:
             raise ValueError("Unknown set for the dataset: ", split)
 
-        self.train_save_path = get_train_save_path(output_dir, chosen_log)
         self.test_save_path = get_test_save_path(infered_file, chosen_log)
 
         return

--- a/kpconv_torch/train.py
+++ b/kpconv_torch/train.py
@@ -92,14 +92,12 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             train=True,
         )
         test_dataset = ModelNet40Dataset(
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             train=False,
         )
         training_sampler = ModelNet40Sampler(
@@ -120,7 +118,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="training",
             use_potentials=True,
         )
@@ -128,7 +125,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="validation",
             use_potentials=True,
         )
@@ -148,7 +144,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="training",
             use_potentials=True,
         )
@@ -156,7 +151,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="validation",
             use_potentials=True,
         )
@@ -176,7 +170,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="training",
             balance_classes=True,
         )
@@ -184,7 +177,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="validation",
             balance_classes=False,
         )
@@ -204,7 +196,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="training",
             use_potentials=True,
         )
@@ -212,7 +203,6 @@ def main(args):
             config=config,
             datapath=args.datapath,
             chosen_log=args.chosen_log,
-            output_dir=args.output_dir,
             split="validation",
             use_potentials=True,
         )

--- a/kpconv_torch/utils/tester.py
+++ b/kpconv_torch/utils/tester.py
@@ -11,7 +11,7 @@ from kpconv_torch.utils.ply import write_ply
 
 
 def get_test_save_path(infered_file, chosen_log):
-    if infered_file is None and chosen_log is None:
+    if chosen_log is None:
         test_path = None
     elif infered_file is not None:
         test_path = Path(infered_file).parent / "test" / Path(chosen_log).name

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from shutil import rmtree
+
+from kpconv_torch.utils import tester
+
+
+def test_get_test_save_path(fixture_path):
+    assert tester.get_test_save_path(infered_file=None, chosen_log=None) is None
+    log_dir = Path(__file__).parent / "Log_test"
+    infered_file = fixture_path / "example.ply"
+    test_path = tester.get_test_save_path(infered_file=infered_file, chosen_log=log_dir)
+    assert test_path == fixture_path / "test" / "Log_test"
+    assert test_path.exists()
+    rmtree(test_path)
+    test_path = tester.get_test_save_path(infered_file=None, chosen_log=log_dir)
+    assert test_path == Path(log_dir) / "test"
+    assert test_path.exists()
+    rmtree(test_path)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from shutil import rmtree
+
+from kpconv_torch.utils import trainer
+
+
+def test_get_train_save_path():
+    assert trainer.get_train_save_path(output_dir=None, chosen_log=None) is None
+    log_dir = Path(__file__).parent / "Log_test"
+    train_path = trainer.get_train_save_path(output_dir=None, chosen_log=log_dir)
+    assert log_dir == train_path
+    assert Path(train_path).exists()
+    rmtree(log_dir)
+    output_dir = Path(__file__).parent / "outputdir"
+    train_path = trainer.get_train_save_path(output_dir=output_dir, chosen_log=None)
+    assert Path(train_path).exists()
+    log_dirs = list(Path(output_dir).iterdir())
+    assert len(log_dirs) == 1
+    rmtree(output_dir)


### PR DESCRIPTION
Preprocessing should store PLY files in `self.train_files_path / "original_ply", this behavior has been unfortunately changed by #29. This PR reverts this specific change, and remove the `output_dir` parameter from dataset constructors (as we do not use `get_train_save_path` anymore, this parameter becomes useless in this context).