### PR TITLE
Detach cli and api

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -39,6 +39,9 @@ The `train` command generates :
     - When the predictions are bad, the intersection tends to be empty and the ratio tends to 0.
 - a `checkpoints` folder, containing `.tar` files, corresponding to the different epochs;
 - a `potentials` folder, containing an `Area_5.ply` file, with validation data inside.
+- two files in a `calibration` sub-folder, which is located in the folder pointed by the `-d` option, containing the data used to train the model:
+    - `batch_limits.pkl`: ;
+    - `neighbors_limits.pkl`: ;
 
 
 ## Test
@@ -53,7 +56,7 @@ The `test` command corresponds to the application of the model on an unlabeled d
 - `-f` or `--filename`: file on which to predict semantic labels, using the trained model (optional).
 
 The `test` command generates:
-- two files, in the folder pointed by the `-d` option, containing the data used to train the model:
+- two files in a `calibration` sub-folder, which is located in the folder pointed by the `-d` option, containing the data used to train the model:
     - `batch_limits.pkl`: ;
     - `neighbors_limits.pkl`: ;
 - three folders, in the folder pointed by the `-l` option, containing the trained model:

--- a/kpconv_torch/datasets/ModelNet40.py
+++ b/kpconv_torch/datasets/ModelNet40.py
@@ -1,3 +1,4 @@
+from os import makedirs
 from os.path import exists, join
 import pickle
 import time
@@ -9,7 +10,6 @@ from torch.utils.data import get_worker_info, Sampler
 from kpconv_torch.datasets.common import grid_subsampling, PointCloudDataset
 from kpconv_torch.utils.config import BColors, Config
 from kpconv_torch.utils.mayavi_visu import show_input_batch
-from kpconv_torch.utils.tester import get_test_save_path
 
 
 class ModelNet40Dataset(PointCloudDataset):
@@ -299,8 +299,6 @@ class ModelNet40Sampler(Sampler):
     def __init__(
         self,
         dataset: ModelNet40Dataset,
-        chosen_log,
-        infered_file,
         use_potential=True,
         balance_labels=False,
     ):
@@ -314,8 +312,8 @@ class ModelNet40Sampler(Sampler):
 
         # Dataset used by the sampler (no copy is made in memory)
         self.dataset = dataset
-
-        self.test_save_path = get_test_save_path(infered_file, chosen_log)
+        self.calibration_path = join(self.dataset.path, "calibration")
+        makedirs(self.calibration_path, exist_ok=True)
 
         # Create potentials
         if self.use_potential:
@@ -444,7 +442,7 @@ class ModelNet40Sampler(Sampler):
         # ***********
 
         # Load batch_limit dictionary
-        batch_lim_file = join(self.test_save_path, "batch_limits.pkl")
+        batch_lim_file = join(self.calibration_path, "batch_limits.pkl")
         if exists(batch_lim_file):
             with open(batch_lim_file, "rb") as file:
                 batch_lim_dict = pickle.load(file)
@@ -475,7 +473,7 @@ class ModelNet40Sampler(Sampler):
         # ***************
 
         # Load neighb_limits dictionary
-        neighb_lim_file = join(self.test_save_path, "neighbors_limits.pkl")
+        neighb_lim_file = join(self.calibration_path, "neighbors_limits.pkl")
         if exists(neighb_lim_file):
             with open(neighb_lim_file, "rb") as file:
                 neighb_lim_dict = pickle.load(file)

--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -14,7 +14,6 @@ from kpconv_torch.datasets.common import grid_subsampling, PointCloudDataset
 from kpconv_torch.utils.config import BColors, Config
 from kpconv_torch.utils.mayavi_visu import show_input_batch
 from kpconv_torch.utils.ply import read_ply, write_ply
-from kpconv_torch.utils.tester import get_test_save_path
 
 
 class NPM3DDataset(PointCloudDataset):
@@ -906,13 +905,13 @@ class NPM3DDataset(PointCloudDataset):
 class NPM3DSampler(Sampler):
     """Sampler for NPM3D"""
 
-    def __init__(self, dataset: NPM3DDataset, chosen_log, infered_file):
+    def __init__(self, dataset: NPM3DDataset):
         Sampler.__init__(self, dataset)
 
         # Dataset used by the sampler (no copy is made in memory)
         self.dataset = dataset
-
-        self.test_save_path = get_test_save_path(infered_file, chosen_log)
+        self.calibration_path = join(self.dataset.path, "calibration")
+        makedirs(self.calibration_path, exist_ok=True)
 
         # Number of step per epoch
         if dataset.set == "training":
@@ -1119,7 +1118,7 @@ class NPM3DSampler(Sampler):
         # ***********
 
         # Load batch_limit dictionary
-        batch_lim_file = join(self.test_save_path, "batch_limits.pkl")
+        batch_lim_file = join(self.calibration_path, "batch_limits.pkl")
         if exists(batch_lim_file):
             with open(batch_lim_file, "rb") as file:
                 batch_lim_dict = pickle.load(file)
@@ -1152,7 +1151,7 @@ class NPM3DSampler(Sampler):
         # ***************
 
         # Load neighb_limits dictionary
-        neighb_lim_file = join(self.test_save_path, "neighbors_limits.pkl")
+        neighb_lim_file = join(self.calibration_path, "neighbors_limits.pkl")
         if exists(neighb_lim_file):
             with open(neighb_lim_file, "rb") as file:
                 neighb_lim_dict = pickle.load(file)

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -14,7 +14,6 @@ from kpconv_torch.datasets.common import grid_subsampling, PointCloudDataset
 from kpconv_torch.utils.config import BColors, Config
 from kpconv_torch.utils.mayavi_visu import show_input_batch
 from kpconv_torch.utils.ply import read_ply, write_ply
-from kpconv_torch.utils.tester import get_test_save_path
 
 
 class S3DISDataset(PointCloudDataset):
@@ -889,13 +888,13 @@ class S3DISDataset(PointCloudDataset):
 class S3DISSampler(Sampler):
     """Sampler for S3DIS"""
 
-    def __init__(self, dataset: S3DISDataset, chosen_log, infered_file):
+    def __init__(self, dataset: S3DISDataset):
         Sampler.__init__(self, dataset)
 
         # Dataset used by the sampler (no copy is made in memory)
         self.dataset = dataset
-
-        self.test_save_path = get_test_save_path(infered_file, chosen_log)
+        self.calibration_path = join(self.dataset.path, "calibration")
+        makedirs(self.calibration_path, exist_ok=True)
 
         # Number of step per epoch
         if dataset.set == "training":
@@ -1102,7 +1101,7 @@ class S3DISSampler(Sampler):
         # ***********
 
         # Load batch_limit dictionary
-        batch_lim_file = join(self.test_save_path, "batch_limits.pkl")
+        batch_lim_file = join(self.calibration_path, "batch_limits.pkl")
         if exists(batch_lim_file):
             with open(batch_lim_file, "rb") as file:
                 batch_lim_dict = pickle.load(file)
@@ -1135,7 +1134,7 @@ class S3DISSampler(Sampler):
         # ***************
 
         # Load neighb_limits dictionary
-        neighb_lim_file = join(self.test_save_path, "neighbors_limits.pkl")
+        neighb_lim_file = join(self.calibration_path, "neighbors_limits.pkl")
         if exists(neighb_lim_file):
             with open(neighb_lim_file, "rb") as file:
                 neighb_lim_dict = pickle.load(file)

--- a/kpconv_torch/datasets/SemanticKitti.py
+++ b/kpconv_torch/datasets/SemanticKitti.py
@@ -1,5 +1,5 @@
 from multiprocessing import Lock
-from os import listdir
+from os import listdir, makedirs
 from os.path import exists, join
 import pickle
 import time
@@ -12,7 +12,6 @@ import yaml
 
 from kpconv_torch.datasets.common import grid_subsampling, PointCloudDataset
 from kpconv_torch.utils.config import BColors, Config
-from kpconv_torch.utils.tester import get_test_save_path
 
 
 class SemanticKittiDataset(PointCloudDataset):
@@ -727,13 +726,13 @@ class SemanticKittiDataset(PointCloudDataset):
 class SemanticKittiSampler(Sampler):
     """Sampler for SemanticKitti"""
 
-    def __init__(self, dataset: SemanticKittiDataset, chosen_log, infered_file):
+    def __init__(self, dataset: SemanticKittiDataset):
         Sampler.__init__(self, dataset)
 
         # Dataset used by the sampler (no copy is made in memory)
         self.dataset = dataset
-
-        self.test_save_path = get_test_save_path(infered_file, chosen_log)
+        self.calibration_path = join(self.dataset.path, "calibration")
+        makedirs(self.calibration_path, exist_ok=True)
 
         # Number of step per epoch
         if dataset.set == "training":
@@ -892,7 +891,7 @@ class SemanticKittiSampler(Sampler):
         # ***********
 
         # Load max_in_limit dictionary
-        max_in_lim_file = join(self.dataset.path, "max_in_limits.pkl")
+        max_in_lim_file = join(self.calibration_path, "max_in_limits.pkl")
         if exists(max_in_lim_file):
             with open(max_in_lim_file, "rb") as file:
                 max_in_lim_dict = pickle.load(file)
@@ -1008,7 +1007,7 @@ class SemanticKittiSampler(Sampler):
         # ***********
 
         # Load batch_limit dictionary
-        batch_lim_file = join(self.dataset.config.get_test_save_path(), "batch_limits.pkl")
+        batch_lim_file = join(self.calibration_path, "batch_limits.pkl")
         if exists(batch_lim_file):
             with open(batch_lim_file, "rb") as file:
                 batch_lim_dict = pickle.load(file)
@@ -1041,7 +1040,7 @@ class SemanticKittiSampler(Sampler):
         # ***************
 
         # Load neighb_limits dictionary
-        neighb_lim_file = join(self.dataset.config.get_test_save_path(), "neighbors_limits.pkl")
+        neighb_lim_file = join(self.calibration_path, "neighbors_limits.pkl")
         if exists(neighb_lim_file):
             with open(neighb_lim_file, "rb") as file:
                 neighb_lim_dict = pickle.load(file)

--- a/kpconv_torch/datasets/Toronto3D.py
+++ b/kpconv_torch/datasets/Toronto3D.py
@@ -1,5 +1,6 @@
 from multiprocessing import Lock
 import os
+from os import makedirs
 from os.path import exists, join
 import pickle
 import time
@@ -14,7 +15,6 @@ from kpconv_torch.datasets.common import grid_subsampling, PointCloudDataset
 from kpconv_torch.utils.config import BColors, Config
 from kpconv_torch.utils.mayavi_visu import show_input_batch
 from kpconv_torch.utils.ply import read_ply, write_ply
-from kpconv_torch.utils.tester import get_test_save_path
 
 
 class Toronto3DDataset(PointCloudDataset):
@@ -894,13 +894,13 @@ class Toronto3DDataset(PointCloudDataset):
 class Toronto3DSampler(Sampler):
     """Sampler for Toronto3D (with features)"""
 
-    def __init__(self, dataset: Toronto3DDataset, chosen_log, infered_file):
+    def __init__(self, dataset: Toronto3DDataset):
         Sampler.__init__(self, dataset)
 
         # Dataset used by the sampler (no copy is made in memory)
         self.dataset = dataset
-
-        self.test_save_path = get_test_save_path(infered_file, chosen_log)
+        self.calibration_path = join(self.dataset.path, "calibration")
+        makedirs(self.calibration_path, exist_ok=True)
 
         # Number of step per epoch
         if dataset.set == "training":
@@ -1107,7 +1107,7 @@ class Toronto3DSampler(Sampler):
         # ***********
 
         # Load batch_limit dictionary
-        batch_lim_file = join(self.test_save_path, "batch_limits.pkl")
+        batch_lim_file = join(self.calibration_path, "batch_limits.pkl")
         if exists(batch_lim_file):
             with open(batch_lim_file, "rb") as file:
                 batch_lim_dict = pickle.load(file)
@@ -1140,7 +1140,7 @@ class Toronto3DSampler(Sampler):
         # ***************
 
         # Load neighb_limits dictionary
-        neighb_lim_file = join(self.test_save_path, "neighbors_limits.pkl")
+        neighb_lim_file = join(self.calibration_path, "neighbors_limits.pkl")
         if exists(neighb_lim_file):
             with open(neighb_lim_file, "rb") as file:
                 neighb_lim_dict = pickle.load(file)

--- a/kpconv_torch/plot_convergence.py
+++ b/kpconv_torch/plot_convergence.py
@@ -1,6 +1,7 @@
 import contextlib
 from os import listdir, remove
 from os.path import exists, isfile, join
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -571,6 +572,10 @@ def experiment_name_2():
 
 
 def main(args):
+    plot(args.datapath)
+
+
+def plot(datapath: Path) -> None:
     ######################################################
     # Choose a list of log to plot together for comparison
     ######################################################
@@ -608,7 +613,7 @@ def main(args):
         if config.dataset.startswith("S3DIS"):
             dataset = S3DISDataset(
                 config=config,
-                datapath=args.datapath,
+                datapath=datapath,
                 load_data=False,
             )
             compare_convergences_segment(dataset, logs, logs_names)

--- a/kpconv_torch/preprocess.py
+++ b/kpconv_torch/preprocess.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from kpconv_torch.datasets.ModelNet40 import (
     ModelNet40Config,
     ModelNet40Dataset,
@@ -21,6 +23,10 @@ from kpconv_torch.datasets.Toronto3D import (
 
 
 def main(args):
+    preprocess(args.datapath, args.dataset)
+
+
+def preprocess(datapath: Path, dataset: str) -> None:
 
     # ############################
     # # Initialize the environment
@@ -29,15 +35,15 @@ def main(args):
     # By modifying the CUDA_VISIBLE_DEVICES environment variable
 
     # Initialize configuration class
-    if args.dataset == "ModelNet40":
+    if dataset == "ModelNet40":
         config = ModelNet40Config()
-    if args.dataset == "NPM3D":
+    if dataset == "NPM3D":
         config = NPM3DConfig()
-    if args.dataset == "S3DIS":
+    if dataset == "S3DIS":
         config = S3DISConfig()
-    if args.dataset == "SemanticKitti":
+    if dataset == "SemanticKitti":
         config = SemanticKittiConfig()
-    elif args.dataset == "Toronto3D":
+    elif dataset == "Toronto3D":
         config = Toronto3DConfig()
 
     ##################################
@@ -54,59 +60,59 @@ def main(args):
     print("Data Preparation")
     print("****************")
 
-    # Initialize datasets and samplers
+    # Initialize datasets
     if config.dataset == "ModelNet40":
-        _ = ModelNet40Dataset(config=config, datapath=args.datapath, train=True)
-        _ = ModelNet40Dataset(config=config, datapath=args.datapath, train=False)
+        _ = ModelNet40Dataset(config=config, datapath=datapath, train=True)
+        _ = ModelNet40Dataset(config=config, datapath=datapath, train=False)
     elif config.dataset == "NPM3D":
         _ = NPM3DDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="training",
             use_potentials=True,
         )
         _ = NPM3DDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="validation",
             use_potentials=True,
         )
     elif config.dataset == "S3DIS":
         _ = S3DISDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="training",
             use_potentials=True,
         )
         _ = S3DISDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="validation",
             use_potentials=True,
         )
     elif config.dataset == "SemanticKitti":
         _ = SemanticKittiDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="training",
             balance_classes=True,
         )
         _ = SemanticKittiDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="validation",
             balance_classes=False,
         )
     elif config.dataset == "Toronto3D":
         _ = Toronto3DDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="training",
             use_potentials=True,
         )
         _ = Toronto3DDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="validation",
             use_potentials=True,
         )

--- a/kpconv_torch/visualize.py
+++ b/kpconv_torch/visualize.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import os
 import time
 
@@ -55,6 +56,10 @@ def model_choice(chosen_log):
 
 
 def main(args):
+    visualize(args.datapath, args.chosen_log)
+
+
+def visualize(datapath: Path, chosen_log: Path) -> None:
 
     # Choose the index of the checkpoint to load OR None if you want to load the current checkpoint
     chkp_idx = None
@@ -63,7 +68,7 @@ def main(args):
     deform_idx = 0
 
     # Deal with 'last_XXX' choices
-    chosen_log = model_choice(args.chosen_log)
+    chosen_log = model_choice(chosen_log)
 
     ############################
     # Initialize the environment
@@ -115,13 +120,13 @@ def main(args):
 
     # Initiate dataset
     if config.dataset.startswith("ModelNet40"):
-        test_dataset = ModelNet40Dataset(config=config, datapath=args.datapath, train=False)
+        test_dataset = ModelNet40Dataset(config=config, datapath=datapath, train=False)
         test_sampler = ModelNet40Sampler(test_dataset)
         collate_fn = ModelNet40Collate
     elif config.dataset == "S3DIS":
         test_dataset = S3DISDataset(
             config=config,
-            datapath=args.datapath,
+            datapath=datapath,
             split="validation",
             use_potentials=True,
         )


### PR DESCRIPTION
This PR creates extra proxy function in each CLI modules, that makes the operations easier through API (no needs for declaring a `Namespace` in order to mimic the CLI).

Example: `train.main(args)` is now calling `train.train(args.datapath, args.chosen_log, args.output_dir, args.dataset)`, and API users may now import the training function like `from kpconv_torch.train import train`. This will pave the way for clear functional tests.

This PR does some extra-work, in order to fix some wrong behavior introduced in #22.

- get_train_save_path and get_test_save_path are used once for all in ModelTrainer and ModelTester. The output is stored into a class attribute for each class.

- Sampler class for each dataset must not depend on chosen_log and filename (this is a clear bug for training, as filename does not exist in such context). As a corollary, calibration .pkl files should not be stored in a experiment-dependant folder. We store them again in the input folder, in a specific "calibration" subfolder.
