### PR TITLE
Draft: Flake8 cleaning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 100
 max-complexity = 15
-ignore = E203,E501,W503,C901
+ignore = E203,W503,C901
 per-file-ignores=kpconv_torch/utils/visualizer.py:B023
 select = C,E,F,W,B,B950
 exclude =

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 100
 max-complexity = 15
-ignore = E203,E501,W503
+ignore = E203,E501,W503,C901
 per-file-ignores=kpconv_torch/utils/visualizer.py:B023
 select = C,E,F,W,B,B950
 exclude =

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax alerts
-          # ignore C901, B950 and E800 in addition to the code ignored in .flake8 (TODO: fix)
-          flake8 $(git ls-files '*.py') --show-source --count --statistics --ignore=E203,E501,W503,C901,B950,E800
+          # ignore C901 in addition to the code ignored in .flake8 (TODO: fix)
+          flake8 $(git ls-files '*.py') --show-source --count --statistics --ignore=E203,W503,C901
 
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide.
-          # Run only on C901, B950 and E800 to visualize the fixes that should still be done
-          flake8 $(git ls-files '*.py') --count --exit-zero --statistics --max-line-length=127 --select=C901,B950,E800
+          # Run only on C901 to visualize the fixes that should still be done
+          flake8 $(git ls-files '*.py') --count --exit-zero --statistics --max-line-length=127 --select=C901
 
       - name: Check code with black
         run: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,634 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=grid_subsampling,radius_neighbors
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: text, parseable, colorized,
+# json2 (improved json format), json (old json format) and msvs (visual
+# studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=torch.*
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/kpconv_torch/datasets/ModelNet40.py
+++ b/kpconv_torch/datasets/ModelNet40.py
@@ -130,9 +130,9 @@ class ModelNet40Dataset(PointCloudDataset):
         return self.num_models
 
     def __getitem__(self, idx_list):
-        """
-        The main thread gives a list of indices to load a batch. Each worker is going to work in parallel to load a
-        different list of indices.
+        """The main thread gives a list of indices to load a batch. Each worker is going to work in
+        parallel to load a different list of indices.
+
         """
 
         ###################
@@ -167,8 +167,6 @@ class ModelNet40Dataset(PointCloudDataset):
         ###################
         # Concatenate batch
         ###################
-
-        # show_ModelNet_examples(tp_list, cloud_normals=tn_list)
 
         stacked_points = np.concatenate(tp_list, axis=0)
         stacked_normals = np.concatenate(tn_list, axis=0)
@@ -421,12 +419,15 @@ class ModelNet40Sampler(Sampler):
         return None
 
     def calibration(self, dataloader, untouched_ratio=0.9, verbose=False):
-        """
-        Method performing batch and neighbors calibration.
-            Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch) so that the
-                               average batch size (number of stacked pointclouds) is the one asked.
-        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors allowed in convolutions)
-                               so that 90% of the neighborhoods remain untouched. There is a limit for each layer.
+        """Method performing batch and neighbors calibration.
+
+        Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch)
+        so that the average batch size (number of stacked pointclouds) is the one asked.
+
+        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors
+        allowed in convolutions) so that 90% of the neighborhoods remain untouched. There is a
+        limit for each layer.
+
         """
 
         ##############################
@@ -740,9 +741,10 @@ class ModelNet40CustomBatch:
         return self.unstack_elements("pools", layer)
 
     def unstack_elements(self, element_name, layer=None, to_numpy=True):
-        """
-        Return a list of the stacked elements in the batch at a certain layer. If no layer is given, then return all
-        layers
+        """Return a list of the stacked elements in the batch at a certain layer.
+
+        If no layer is given, then return all layers.
+
         """
 
         if element_name == "points":
@@ -806,7 +808,8 @@ class ModelNet40Config(Config):
     # Dataset name
     dataset = "ModelNet40"
 
-    # Number of classes in the dataset (This value is overwritten by dataset class when Initializating dataset).
+    # Number of classes in the dataset (This value is overwritten by dataset class when
+    # Initializating dataset).
     num_classes = None
 
     # Type of task performed on this dataset (also overwritten)
@@ -851,10 +854,12 @@ class ModelNet40Config(Config):
     # Radius of convolution in "number grid cell". (2.5 is the standard value)
     conv_radius = 2.5
 
-    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can spread out
+    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can
+    # spread out
     deform_radius = 6.0
 
-    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the standard value)
+    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the
+    # standard value)
     KP_extent = 1.2
 
     # Behavior of convolutions in ('constant', 'linear', 'gaussian')
@@ -873,9 +878,8 @@ class ModelNet40Config(Config):
     use_batch_norm = True
     batch_norm_momentum = 0.05
 
-    # Deformable offset loss
-    # 'point2point' fitting geometry by penalizing distance from deform point to input points
-    # 'point2plane' fitting geometry by penalizing distance from deform point to input point triplet (not implemented)
+    # Deformable offset loss : fitting geometry by penalizing distance from deform point to input
+    # points ('point2point'), or to input point triplet ('point2plane', not implemented)
     deform_fitting_mode = "point2point"
     deform_fitting_power = 1.0  # Multiplier for the fitting/repulsive loss
     deform_lr_factor = 0.1  # Multiplier for learning rate applied to the deformations
@@ -916,9 +920,11 @@ class ModelNet40Config(Config):
     augment_color = 1.0
 
     # The way we balance segmentation loss
-    #   > 'none': Each point in the whole batch has the same contribution.
-    #   > 'class': Each class has the same contribution (points are weighted according to class balance)
-    #   > 'batch': Each cloud in the batch has the same contribution (points are weighted according cloud sizes)
+    # - 'none': Each point in the whole batch has the same contribution.
+    # - 'class': Each class has the same contribution (points are weighted according to class
+    #   balance)
+    # - 'batch': Each cloud in the batch has the same contribution (points are weighted according
+    #   cloud sizes)
     segloss_balance = "none"
 
     # Do we need to save convergence
@@ -960,7 +966,6 @@ def debug_timing(dataset, sampler, loader):
     for _ in range(10):
 
         for batch_i, batch in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]
@@ -1050,7 +1055,6 @@ def debug_batch_and_neighbors_calib(dataset, sampler, loader):
     for _ in range(10):
 
         for batch_i, _ in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]
@@ -1091,7 +1095,8 @@ class ModelNet40WorkerInitDebug:
         # Get associated dataset
         dataset = worker_info.dataset  # the dataset copy in this worker process
 
-        # In windows, each worker has its own copy of the dataset. In Linux, this is shared in memory
+        # In windows, each worker has its own copy of the dataset. In Linux, this is shared in
+        # memory
         print(dataset.input_labels.__array_interface__["data"])
         print(worker_info.dataset.input_labels.__array_interface__["data"])
         print(self.dataset.input_labels.__array_interface__["data"])

--- a/kpconv_torch/datasets/NPM3D.py
+++ b/kpconv_torch/datasets/NPM3D.py
@@ -76,7 +76,6 @@ class NPM3DDataset(PointCloudDataset):
         self.use_potentials = use_potentials
 
         # Path of the training files
-        # self.train_files_path = 'original_ply'
         self.train_files_path = "train"
         self.original_ply_path = "original_ply"
 
@@ -95,7 +94,6 @@ class NPM3DDataset(PointCloudDataset):
         ]
         self.all_splits = [0, 1, 2, 3, 4, 5, 6]
         self.validation_split = 1
-        # self.test_cloud_names = ['ajaccio_2', 'ajaccio_57', 'dijon_9']
         self.test_splits = [4, 5, 6]
         self.train_splits = [0, 2, 3]
 
@@ -230,9 +228,9 @@ class NPM3DDataset(PointCloudDataset):
         return len(self.cloud_names)
 
     def __getitem__(self, batch_i):
-        """
-        The main thread gives a list of indices to load a batch. Each worker is going to work in parallel to load a
-        different list of indices.
+        """The main thread gives a list of indices to load a batch. Each worker is going to work in
+        parallel to load a different list of indices.
+
         """
 
         if self.use_potentials:
@@ -355,7 +353,6 @@ class NPM3DDataset(PointCloudDataset):
 
             # Collect labels and colors
             input_points = (points[input_inds] - center_point).astype(np.float32)
-            # input_colors = self.input_colors[cloud_ind][input_inds]
             if self.set in ["test", "ERF"]:
                 input_labels = np.zeros(input_points.shape[0])
             else:
@@ -367,12 +364,7 @@ class NPM3DDataset(PointCloudDataset):
             # Data augmentation
             input_points, scale, R = self.augmentation_transform(input_points)
 
-            # Color augmentation
-            # if np.random.rand() > self.config.augment_color:
-            #    input_colors *= 0
-
             # Get original height as additional feature
-            # input_features = np.hstack((input_colors, input_points[:, 2:] + center_point[:, 2:])).astype(np.float32)
             input_features = np.hstack(input_points[:, 2:] + center_point[:, 2:]).astype(np.float32)
 
             t += [time.time()]
@@ -393,11 +385,6 @@ class NPM3DDataset(PointCloudDataset):
             # In case batch is full, stop
             if batch_n > int(self.batch_limit):
                 break
-
-            # Randomly drop some points (act as an augmentation process and a safety for GPU memory consumption)
-            # if n > int(self.batch_limit):
-            #    input_inds = np.random.choice(input_inds, size=int(self.batch_limit) - 1, replace=False)
-            #    n = input_inds.shape[0]
 
         ###################
         # Concatenate batch
@@ -571,7 +558,6 @@ class NPM3DDataset(PointCloudDataset):
 
             # Collect labels and colors
             input_points = (points[input_inds] - center_point).astype(np.float32)
-            # input_colors = self.input_colors[cloud_ind][input_inds]
             if self.set in ["test", "ERF"]:
                 input_labels = np.zeros(input_points.shape[0])
             else:
@@ -580,10 +566,6 @@ class NPM3DDataset(PointCloudDataset):
 
             # Data augmentation
             input_points, scale, R = self.augmentation_transform(input_points)
-
-            # Color augmentation
-            # if np.random.rand() > self.config.augment_color:
-            #   input_colors *= 0
 
             # Get original height as additional feature
             input_features = np.hstack(input_points[:, 2:] + center_point[:, 2:]).astype(np.float32)
@@ -604,11 +586,6 @@ class NPM3DDataset(PointCloudDataset):
             # In case batch is full, stop
             if batch_n > int(self.batch_limit):
                 break
-
-            # Randomly drop some points (act as an augmentation process and a safety for GPU memory consumption)
-            # if n > int(self.batch_limit):
-            #    input_inds = np.random.choice(input_inds, size=int(self.batch_limit) - 1, replace=False)
-            #    n = input_inds.shape[0]
 
         ###################
         # Concatenate batch
@@ -746,7 +723,6 @@ class NPM3DDataset(PointCloudDataset):
 
                 # read ply with data
                 data = read_ply(sub_ply_file)
-                # sub_colors = np.vstack((data['red'], data['green'], data['blue'])).T
                 sub_labels = data["classification"]
 
                 # Read pkl with search tree
@@ -759,7 +735,6 @@ class NPM3DDataset(PointCloudDataset):
                 # Read ply file
                 data = read_ply(file_path)
                 points = np.vstack((data["x"], data["y"], data["z"])).T
-                # colors = np.vstack((data['red'], data['green'], data['blue'])).T
 
                 # Fake labels for test data
                 if self.set == "test":
@@ -769,15 +744,10 @@ class NPM3DDataset(PointCloudDataset):
 
                 # Subsample cloud
                 sub_points, sub_labels = grid_subsampling(points, labels=labels, sampleDl=dl)
-
-                # Rescale float color and squeeze label
-                # sub_colors = sub_colors / 255
                 sub_labels = np.squeeze(sub_labels)
 
                 # Get chosen neighborhoods
                 search_tree = KDTree(sub_points, leaf_size=10)
-                # search_tree = nnfln.KDTree(n_neighbors=1, metric='L2', leaf_size=10)
-                # search_tree.fit(sub_points)
 
                 # Save KDTree
                 with open(KDTree_file, "wb") as f:
@@ -788,7 +758,6 @@ class NPM3DDataset(PointCloudDataset):
 
             # Fill data containers
             self.input_trees += [search_tree]
-            # self.input_colors += [sub_colors]
             self.input_labels += [sub_labels]
 
             size = sub_labels.shape[0] * 4 * 7
@@ -878,7 +847,6 @@ class NPM3DDataset(PointCloudDataset):
 
                     # Compute projection inds
                     idxs = self.input_trees[i].query(points, return_distance=False)
-                    # dists, idxs = self.input_trees[i_cloud].kneighbors(points)
                     proj_inds = np.squeeze(idxs).astype(np.int32)
 
                     # Save
@@ -922,9 +890,9 @@ class NPM3DSampler(Sampler):
         return
 
     def __iter__(self):
-        """
-        Yield next batch indices here. In this dataset, this is a dummy sampler that yield the index of batch element
-        (input sphere) in epoch instead of the list of point indices
+        """Yield next batch indices here. In this dataset, this is a dummy sampler that yield
+        the index of batch element (input sphere) in epoch instead of the list of point indices.
+
         """
 
         if not self.dataset.use_potentials:
@@ -1014,11 +982,11 @@ class NPM3DSampler(Sampler):
         return self.N
 
     def fast_calib(self):
-        """
-        This method calibrates the batch sizes while ensuring the potentials are well initialized. Indeed on a dataset
-        like Semantic3D, before potential have been updated over the dataset, there are cahnces that all the dense area
-        are picked in the begining and in the end, we will have very large batch of small point clouds
-        :return:
+        """This method calibrates the batch sizes while ensuring the potentials are well
+        initialized. Indeed on a dataset like Semantic3D, before potential have been updated over
+        the dataset, there are chances that all the dense area are picked in the begining and in
+        the end, we will have very large batch of small point clouds.
+
         """
 
         # Estimated average batch size and target value
@@ -1097,12 +1065,15 @@ class NPM3DSampler(Sampler):
                 break
 
     def calibration(self, dataloader, untouched_ratio=0.9, verbose=False, force_redo=False):
-        """
-        Method performing batch and neighbors calibration.
-            Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch) so that the
-                               average batch size (number of stacked pointclouds) is the one asked.
-        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors allowed in convolutions)
-                               so that 90% of the neighborhoods remain untouched. There is a limit for each layer.
+        """Method performing batch and neighbors calibration.
+
+        Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch)
+        so that the average batch size (number of stacked pointclouds) is the one asked.
+
+        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors
+        allowed in convolutions) so that 90% of the neighborhoods remain untouched. There is a
+        limit for each layer.
+
         """
 
         ##############################
@@ -1130,7 +1101,10 @@ class NPM3DSampler(Sampler):
             sampler_method = "potentials"
         else:
             sampler_method = "random"
-        key = f"{sampler_method}_{self.dataset.config.in_radius:3f}_{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+        key = (
+            f"{sampler_method}_{self.dataset.config.in_radius:3f}_"
+            "{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+        )
         if not redo and key in batch_lim_dict:
             self.dataset.batch_limit[0] = batch_lim_dict[key]
         else:
@@ -1218,8 +1192,9 @@ class NPM3DSampler(Sampler):
             # Expected batch size order of magnitude
             expected_N = 100000
 
-            # Calibration parameters. Higher means faster but can also become unstable
-            # Reduce Kp and Kd if your GP Uis small as the total number of points per batch will be smaller
+            # Calibration parameters. Higher means faster but can also become unstable.
+
+            # Reduce Kp/Kd if small GPU: the total number of points per batch will be smaller
             low_pass_T = 100
             Kp = expected_N / 200
             Ki = 0.001 * Kp
@@ -1321,7 +1296,8 @@ class NPM3DSampler(Sampler):
                 import matplotlib.pyplot as plt
 
                 print(
-                    "ERROR: It seems that the calibration have not reached convergence. Here are some plot to understand why:"
+                    "ERROR: It seems that the calibration have not reached convergence. "
+                    "are are some plot to understand why:"
                 )
                 print("If you notice unstability, reduce the expected_N value")
                 print("If convergece is too slow, increase the expected_N value")
@@ -1377,7 +1353,11 @@ class NPM3DSampler(Sampler):
                 sampler_method = "potentials"
             else:
                 sampler_method = "random"
-            key = "{sampler_method}_{self.dataset.config.in_radius:3f}_{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+            key = (
+                "{sampler_method}_{self.dataset.config.in_radius:3f}_"
+                "{self.dataset.config.first_subsampling_dl:3f}_"
+                "{self.dataset.config.batch_num:d}"
+            )
             batch_lim_dict[key] = float(self.dataset.batch_limit)
             with open(batch_lim_file, "wb") as file:
                 pickle.dump(batch_lim_dict, file)
@@ -1487,9 +1467,10 @@ class NPM3DCustomBatch:
         return self.unstack_elements("pools", layer)
 
     def unstack_elements(self, element_name, layer=None, to_numpy=True):
-        """
-        Return a list of the stacked elements in the batch at a certain layer. If no layer is given, then return all
-        layers
+        """Return a list of the stacked elements in the batch at a certain layer.
+
+        If no layer is given, then return all layers.
+
         """
 
         if element_name == "points":
@@ -1553,7 +1534,8 @@ class NPM3DConfig(Config):
     # Dataset name
     dataset = "NPM3D"
 
-    # Number of classes in the dataset (This value is overwritten by dataset class when Initializating dataset).
+    # Number of classes in the dataset (This value is overwritten by dataset class when
+    # Initializating dataset).
     num_classes = None
 
     # Type of task performed on this dataset (also overwritten)
@@ -1608,10 +1590,12 @@ class NPM3DConfig(Config):
     # Radius of convolution in "number grid cell". (2.5 is the standard value)
     conv_radius = 2.5
 
-    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can spread out
+    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can
+    # spread out
     deform_radius = 5.0
 
-    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the standard value)
+    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the
+    # standard value)
     KP_extent = 1.2
 
     # Behavior of convolutions in ('constant', 'linear', 'gaussian')
@@ -1631,9 +1615,8 @@ class NPM3DConfig(Config):
     use_batch_norm = True
     batch_norm_momentum = 0.02
 
-    # Deformable offset loss
-    # 'point2point' fitting geometry by penalizing distance from deform point to input points
-    # 'point2plane' fitting geometry by penalizing distance from deform point to input point triplet (not implemented)
+    # Deformable offset loss : fitting geometry by penalizing distance from deform point to input
+    # points ('point2point'), or to input point triplet ('point2plane', not implemented)
     deform_fitting_mode = "point2point"
     deform_fitting_power = 1.0  # Multiplier for the fitting/repulsive loss
     deform_lr_factor = 0.1  # Multiplier for learning rate applied to the deformations
@@ -1674,9 +1657,11 @@ class NPM3DConfig(Config):
     augment_color = 0.8
 
     # The way we balance segmentation loss
-    #   > 'none': Each point in the whole batch has the same contribution.
-    #   > 'class': Each class has the same contribution (points are weighted according to class balance)
-    #   > 'batch': Each cloud in the batch has the same contribution (points are weighted according cloud sizes)
+    # - 'none': Each point in the whole batch has the same contribution.
+    # - 'class': Each class has the same contribution (points are weighted according to class
+    #   balance)
+    # - 'batch': Each cloud in the batch has the same contribution (points are weighted according
+    #   cloud sizes)
     segloss_balance = "none"
 
     # Do we need to save convergence
@@ -1734,7 +1719,6 @@ def debug_timing(dataset, loader):
     for _ in range(10):
 
         for batch_i, batch in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]
@@ -1826,7 +1810,6 @@ def debug_batch_and_neighbors_calib(dataset, loader):
     for _ in range(10):
 
         for batch_i, _ in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -20,7 +20,6 @@ from kpconv_torch.io.ply import read_ply, write_ply
 from kpconv_torch.io.xyz import read_xyz
 
 
-
 class S3DISDataset(PointCloudDataset):
     """Class to handle S3DIS dataset."""
 
@@ -165,10 +164,9 @@ class S3DISDataset(PointCloudDataset):
         return len(self.cloud_names)
 
     def __getitem__(self, batch_i):
-        """
-        The main thread gives a list of indices to load a batch.
-        Each worker is going to work in parallel to load a different
-        list of indices.
+        """The main thread gives a list of indices to load a batch.
+        Each worker is going to work in parallel to load a different list of indices.
+
         """
 
         if self.use_potentials:
@@ -330,11 +328,6 @@ class S3DISDataset(PointCloudDataset):
             # In case batch is full, stop
             if batch_n > int(self.batch_limit):
                 break
-
-            # Randomly drop some points (act as an augmentation process and a safety for GPU memory consumption)
-            # if n > int(self.batch_limit):
-            #    input_inds = np.random.choice(input_inds, size=int(self.batch_limit) - 1, replace=False)
-            #    n = input_inds.shape[0]
 
         ###################
         # Concatenate batch
@@ -544,11 +537,6 @@ class S3DISDataset(PointCloudDataset):
             if batch_n > int(self.batch_limit):
                 break
 
-            # Randomly drop some points (act as an augmentation process and a safety for GPU memory consumption)
-            # if n > int(self.batch_limit):
-            #    input_inds = np.random.choice(input_inds, size=int(self.batch_limit) - 1, replace=False)
-            #    n = input_inds.shape[0]
-
         ###################
         # Concatenate batch
         ###################
@@ -688,8 +676,8 @@ class S3DISDataset(PointCloudDataset):
         # Check if inputs have already been computed
         if exists(KDTree_file):
             print(
-                f"\nFound KDTree for cloud {cloud_name}, \
-                    subsampled at {self.config.first_subsampling_dl:3f}"
+                f"\nFound KDTree for cloud {cloud_name}, "
+                f"subsampled at {self.config.first_subsampling_dl:3f}"
             )
 
             # read ply with data
@@ -701,8 +689,8 @@ class S3DISDataset(PointCloudDataset):
 
         else:
             print(
-                f"\nPreparing KDTree for cloud {cloud_name}, \
-                    subsampled at {self.config.first_subsampling_dl:3f}"
+                f"\nPreparing KDTree for cloud {cloud_name}, subsampled at "
+                f"{self.config.first_subsampling_dl:3f}"
             )
 
             points, colors, labels = self.read_input(file_path)
@@ -721,8 +709,6 @@ class S3DISDataset(PointCloudDataset):
 
             # Get chosen neighborhoods
             search_tree = KDTree(sub_points, leaf_size=10)
-            # search_tree = nnfln.KDTree(n_neighbors=1, metric='L2', leaf_size=10)
-            # search_tree.fit(sub_points)
 
             # Save KDTree
             with open(KDTree_file, "wb") as f:
@@ -796,7 +782,6 @@ class S3DISDataset(PointCloudDataset):
 
             # Compute projection inds
             idxs = input_tree.query(points, return_distance=False)
-            # dists, idxs = self.input_trees[i_cloud].kneighbors(points)
             proj_inds = np.squeeze(idxs).astype(np.int32)
 
             # Save
@@ -907,9 +892,9 @@ class S3DISSampler(Sampler):
         return
 
     def __iter__(self):
-        """
-        Yield next batch indices here. In this dataset, this is a dummy sampler that yield the index of batch element
-        (input sphere) in epoch instead of the list of point indices
+        """Yield next batch indices here. In this dataset, this is a dummy sampler that yield
+        the index of batch element (input sphere) in epoch instead of the list of point indices.
+
         """
 
         if not self.dataset.use_potentials:
@@ -999,11 +984,11 @@ class S3DISSampler(Sampler):
         return self.N
 
     def fast_calib(self):
-        """
-        This method calibrates the batch sizes while ensuring the potentials are well initialized. Indeed on a dataset
-        like Semantic3D, before potential have been updated over the dataset, there are cahnces that all the dense area
-        are picked in the begining and in the end, we will have very large batch of small point clouds
-        :return:
+        """This method calibrates the batch sizes while ensuring the potentials are well
+        initialized. Indeed on a dataset like Semantic3D, before potential have been updated over
+        the dataset, there are cahnces that all the dense area are picked in the begining and in
+        the end, we will have very large batch of small point clouds :return:
+
         """
 
         # Estimated average batch size and target value
@@ -1082,12 +1067,15 @@ class S3DISSampler(Sampler):
                 break
 
     def calibration(self, dataloader, untouched_ratio=0.9, verbose=False, force_redo=False):
-        """
-        Method performing batch and neighbors calibration.
-            Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch) so that the
-                               average batch size (number of stacked pointclouds) is the one asked.
-        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors allowed in convolutions)
-                               so that 90% of the neighborhoods remain untouched. There is a limit for each layer.
+        """Method performing batch and neighbors calibration.
+
+        Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch)
+        so that the average batch size (number of stacked pointclouds) is the one asked.
+
+        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors
+        allowed in convolutions) so that 90% of the neighborhoods remain untouched. There is a
+        limit for each layer.
+
         """
 
         ##############################
@@ -1115,7 +1103,10 @@ class S3DISSampler(Sampler):
             sampler_method = "potentials"
         else:
             sampler_method = "random"
-        key = f"{sampler_method}_{self.dataset.config.in_radius:3f}_{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num}"
+        key = (
+            f"{sampler_method}_{self.dataset.config.in_radius:3f}_"
+            "{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num}"
+        )
         if not redo and key in batch_lim_dict:
             self.dataset.batch_limit[0] = batch_lim_dict[key]
         else:
@@ -1204,7 +1195,7 @@ class S3DISSampler(Sampler):
             expected_N = 100000
 
             # Calibration parameters. Higher means faster but can also become unstable
-            # Reduce Kp and Kd if your GP Uis small as the total number of points per batch will be smaller
+            # Reduce Kp/Kd if small GPU: the total number of points per batch will be smaller
             low_pass_T = 100
             Kp = expected_N / 200
             Ki = 0.001 * Kp
@@ -1306,7 +1297,8 @@ class S3DISSampler(Sampler):
                 import matplotlib.pyplot as plt
 
                 print(
-                    "ERROR: It seems that the calibration have not reached convergence. Here are some plot to understand why:"
+                    "ERROR: It seems that the calibration have not reached convergence. "
+                    "Here are some plot to understand why:"
                 )
                 print("If you notice unstability, reduce the expected_N value")
                 print("If convergece is too slow, increase the expected_N value")
@@ -1362,7 +1354,10 @@ class S3DISSampler(Sampler):
                 sampler_method = "potentials"
             else:
                 sampler_method = "random"
-            key = f"{sampler_method}_{self.dataset.config.in_radius:3f}_{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+            key = (
+                f"{sampler_method}_{self.dataset.config.in_radius:3f}_"
+                "{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+            )
             batch_lim_dict[key] = float(self.dataset.batch_limit)
             with open(batch_lim_file, "wb") as file:
                 pickle.dump(batch_lim_dict, file)
@@ -1472,9 +1467,10 @@ class S3DISCustomBatch:
         return self.unstack_elements("pools", layer)
 
     def unstack_elements(self, element_name, layer=None, to_numpy=True):
-        """
-        Return a list of the stacked elements in the batch at a certain layer. If no layer is given, then return all
-        layers
+        """Return a list of the stacked elements in the batch at a certain layer.
+
+        If no layer is given, then return all layers.
+
         """
 
         if element_name == "points":
@@ -1537,7 +1533,8 @@ class S3DISConfig(Config):
     # Dataset name
     dataset = "S3DIS"
 
-    # Number of classes in the dataset (This value is overwritten by dataset class when Initializating dataset).
+    # Number of classes in the dataset (This value is overwritten by dataset class when
+    # Initializating dataset).
     num_classes = None
 
     # Type of task performed on this dataset (also overwritten)
@@ -1590,10 +1587,12 @@ class S3DISConfig(Config):
     # Radius of convolution in "number grid cell". (2.5 is the standard value)
     conv_radius = 2.5
 
-    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can spread out
+    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can
+    # spread out
     deform_radius = 5.0
 
-    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the standard value)
+    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the
+    # standard value)
     KP_extent = 1.2
 
     # Behavior of convolutions in ('constant', 'linear', 'gaussian')
@@ -1613,9 +1612,8 @@ class S3DISConfig(Config):
     use_batch_norm = True
     batch_norm_momentum = 0.02
 
-    # Deformable offset loss
-    # 'point2point' fitting geometry by penalizing distance from deform point to input points
-    # 'point2plane' fitting geometry by penalizing distance from deform point to input point triplet (not implemented)
+    # Deformable offset loss : fitting geometry by penalizing distance from deform point to input
+    # points ('point2point'), or to input point triplet ('point2plane', not implemented)
     deform_fitting_mode = "point2point"
     deform_fitting_power = 1.0  # Multiplier for the fitting/repulsive loss
     deform_lr_factor = 0.1  # Multiplier for learning rate applied to the deformations
@@ -1655,9 +1653,11 @@ class S3DISConfig(Config):
     augment_color = 0.8
 
     # The way we balance segmentation loss
-    #   > 'none': Each point in the whole batch has the same contribution.
-    #   > 'class': Each class has the same contribution (points are weighted according to class balance)
-    #   > 'batch': Each cloud in the batch has the same contribution (points are weighted according cloud sizes)
+    # - 'none': Each point in the whole batch has the same contribution.
+    # - 'class': Each class has the same contribution (points are weighted according to class
+    #   balance)
+    # - 'batch': Each cloud in the batch has the same contribution (points are weighted according
+    #   cloud sizes)
     segloss_balance = "none"
 
     # Do we need to save convergence
@@ -1716,7 +1716,6 @@ def debug_timing(dataset, loader):
 
     for _ in range(10):
         for batch_i, batch in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]
@@ -1807,7 +1806,6 @@ def debug_batch_and_neighbors_calib(dataset, loader):
 
     for _ in range(10):
         for batch_i, _ in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]

--- a/kpconv_torch/datasets/Toronto3D.py
+++ b/kpconv_torch/datasets/Toronto3D.py
@@ -217,9 +217,9 @@ class Toronto3DDataset(PointCloudDataset):
         return len(self.cloud_names)
 
     def __getitem__(self, batch_i):
-        """
-        The main thread gives a list of indices to load a batch. Each worker is going to work in parallel to load a
-        different list of indices.
+        """The main thread gives a list of indices to load a batch. Each worker is going to work in
+        parallel to load a different list of indices.
+
         """
 
         if self.use_potentials:
@@ -381,11 +381,6 @@ class Toronto3DDataset(PointCloudDataset):
             # In case batch is full, stop
             if batch_n > int(self.batch_limit):
                 break
-
-            # Randomly drop some points (act as an augmentation process and a safety for GPU memory consumption)
-            # if n > int(self.batch_limit):
-            #    input_inds = np.random.choice(input_inds, size=int(self.batch_limit) - 1, replace=False)
-            #    n = input_inds.shape[0]
 
         ###################
         # Concatenate batch
@@ -595,11 +590,6 @@ class Toronto3DDataset(PointCloudDataset):
             if batch_n > int(self.batch_limit):
                 break
 
-            # Randomly drop some points (act as an augmentation process and a safety for GPU memory consumption)
-            # if n > int(self.batch_limit):
-            #    input_inds = np.random.choice(input_inds, size=int(self.batch_limit) - 1, replace=False)
-            #    n = input_inds.shape[0]
-
         ###################
         # Concatenate batch
         ###################
@@ -757,8 +747,6 @@ class Toronto3DDataset(PointCloudDataset):
 
                 # Get chosen neighborhoods
                 search_tree = KDTree(sub_points, leaf_size=10)
-                # search_tree = nnfln.KDTree(n_neighbors=1, metric='L2', leaf_size=10)
-                # search_tree.fit(sub_points)
 
                 # Save KDTree
                 with open(KDTree_file, "wb") as f:
@@ -867,7 +855,6 @@ class Toronto3DDataset(PointCloudDataset):
 
                     # Compute projection inds
                     idxs = self.input_trees[i].query(points, return_distance=False)
-                    # dists, idxs = self.input_trees[i_cloud].kneighbors(points)
                     proj_inds = np.squeeze(idxs).astype(np.int32)
 
                     # Save
@@ -911,9 +898,9 @@ class Toronto3DSampler(Sampler):
         return
 
     def __iter__(self):
-        """
-        Yield next batch indices here. In this dataset, this is a dummy sampler that yield the index of batch element
-        (input sphere) in epoch instead of the list of point indices
+        """Yield next batch indices here. In this dataset, this is a dummy sampler that yield
+        the index of batch element (input sphere) in epoch instead of the list of point indices.
+
         """
 
         if not self.dataset.use_potentials:
@@ -1003,11 +990,11 @@ class Toronto3DSampler(Sampler):
         return self.N
 
     def fast_calib(self):
-        """
-        This method calibrates the batch sizes while ensuring the potentials are well initialized. Indeed on a dataset
-        like Semantic3D, before potential have been updated over the dataset, there are chances that all the dense area
-        are picked in the begining and in the end, we will have very large batch of small point clouds
-        :return:
+        """This method calibrates the batch sizes while ensuring the potentials are well
+        initialized. Indeed on a dataset like Semantic3D, before potential have been updated over
+        the dataset, there are chances that all the dense area are picked in the begining and in
+        the end, we will have very large batch of small point clouds :return:
+
         """
 
         # Estimated average batch size and target value
@@ -1086,12 +1073,15 @@ class Toronto3DSampler(Sampler):
                 break
 
     def calibration(self, dataloader, untouched_ratio=0.9, verbose=False, force_redo=False):
-        """
-        Method performing batch and neighbors calibration.
-            Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch) so that the
-                               average batch size (number of stacked pointclouds) is the one asked.
-        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors allowed in convolutions)
-                               so that 90% of the neighborhoods remain untouched. There is a limit for each layer.
+        """Method performing batch and neighbors calibration.
+
+        Batch calibration: Set "batch_limit" (the maximum number of points allowed in every batch)
+        so that the average batch size (number of stacked pointclouds) is the one asked.
+
+        Neighbors calibration: Set the "neighborhood_limits" (the maximum number of neighbors
+        allowed in convolutions) so that 90% of the neighborhoods remain untouched. There is a
+        limit for each layer.
+
         """
 
         ##############################
@@ -1119,7 +1109,10 @@ class Toronto3DSampler(Sampler):
             sampler_method = "potentials"
         else:
             sampler_method = "random"
-        key = f"{sampler_method}_{self.dataset.config.in_radius:3f}_{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+        key = (
+            f"{sampler_method}_{self.dataset.config.in_radius:3f}_"
+            "{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+        )
         if not redo and key in batch_lim_dict:
             self.dataset.batch_limit[0] = batch_lim_dict[key]
         else:
@@ -1208,7 +1201,7 @@ class Toronto3DSampler(Sampler):
             expected_N = 100000
 
             # Calibration parameters. Higher means faster but can also become unstable
-            # Reduce Kp and Kd if your GP Uis small as the total number of points per batch will be smaller
+            # Reduce Kp/Kd if small GPU: the total number of points per batch will be smaller
             low_pass_T = 100
             Kp = expected_N / 200
             Ki = 0.001 * Kp
@@ -1310,7 +1303,8 @@ class Toronto3DSampler(Sampler):
                 import matplotlib.pyplot as plt
 
                 print(
-                    "ERROR: It seems that the calibration have not reached convergence. Here are some plot to understand why:"
+                    "ERROR: It seems that the calibration have not reached convergence. "
+                    "Here are some plot to understand why:"
                 )
                 print("If you notice unstability, reduce the expected_N value")
                 print("If convergece is too slow, increase the expected_N value")
@@ -1366,7 +1360,10 @@ class Toronto3DSampler(Sampler):
                 sampler_method = "potentials"
             else:
                 sampler_method = "random"
-            key = f"{sampler_method}_{self.dataset.config.in_radius:3f}_{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+            key = (
+                f"{sampler_method}_{self.dataset.config.in_radius:3f}_"
+                "{self.dataset.config.first_subsampling_dl:3f}_{self.dataset.config.batch_num:d}"
+            )
             batch_lim_dict[key] = float(self.dataset.batch_limit)
             with open(batch_lim_file, "wb") as file:
                 pickle.dump(batch_lim_dict, file)
@@ -1476,9 +1473,10 @@ class Toronto3DCustomBatch:
         return self.unstack_elements("pools", layer)
 
     def unstack_elements(self, element_name, layer=None, to_numpy=True):
-        """
-        Return a list of the stacked elements in the batch at a certain layer. If no layer is given, then return all
-        layers
+        """Return a list of the stacked elements in the batch at a certain layer.
+
+        If no layer is given, then return all layers.
+
         """
 
         if element_name == "points":
@@ -1542,7 +1540,8 @@ class Toronto3DConfig(Config):
     # Dataset name
     dataset = "Toronto3D"
 
-    # Number of classes in the dataset (This value is overwritten by dataset class when Initializating dataset).
+    # Number of classes in the dataset (This value is overwritten by dataset class when
+    # Initializating dataset).
     num_classes = None
 
     # Type of task performed on this dataset (also overwritten)
@@ -1597,10 +1596,12 @@ class Toronto3DConfig(Config):
     # Radius of convolution in "number grid cell". (2.5 is the standard value)
     conv_radius = 2.5
 
-    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can spread out
+    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can
+    # spread out
     deform_radius = 5.0
 
-    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the standard value)
+    # Radius of the area of influence of each kernel point in "number grid cell". (1.0 is the
+    # standard value)
     KP_extent = 1.0
 
     # Behavior of convolutions in ('constant', 'linear', 'gaussian')
@@ -1620,9 +1621,8 @@ class Toronto3DConfig(Config):
     use_batch_norm = True
     batch_norm_momentum = 0.02
 
-    # Deformable offset loss
-    # 'point2point' fitting geometry by penalizing distance from deform point to input points
-    # 'point2plane' fitting geometry by penalizing distance from deform point to input point triplet (not implemented)
+    # Deformable offset loss : fitting geometry by penalizing distance from deform point to input
+    # points ('point2point'), or to input point triplet ('point2plane', not implemented)
     deform_fitting_mode = "point2point"
     deform_fitting_power = 1.0  # Multiplier for the fitting/repulsive loss
     deform_lr_factor = 0.1  # Multiplier for learning rate applied to the deformations
@@ -1663,9 +1663,11 @@ class Toronto3DConfig(Config):
     augment_color = 0.8
 
     # The way we balance segmentation loss
-    #   > 'none': Each point in the whole batch has the same contribution.
-    #   > 'class': Each class has the same contribution (points are weighted according to class balance)
-    #   > 'batch': Each cloud in the batch has the same contribution (points are weighted according cloud sizes)
+    # - 'none': Each point in the whole batch has the same contribution.
+    # - 'class': Each class has the same contribution (points are weighted according to class
+    #   balance)
+    # - 'batch': Each cloud in the batch has the same contribution (points are weighted according
+    #   cloud sizes)
     segloss_balance = "none"
 
     # Do we need to save convergence
@@ -1724,7 +1726,6 @@ def debug_timing(dataset, loader):
     for _ in range(10):
 
         for batch_i, batch in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]
@@ -1817,7 +1818,6 @@ def debug_batch_and_neighbors_calib(dataset, loader):
     for _ in range(10):
 
         for batch_i, _ in enumerate(loader):
-            # print(batch_i, tuple(points.shape),  tuple(normals.shape), labels, indices, in_sizes)
 
             # New time
             t = t[-1:]

--- a/kpconv_torch/io/las.py
+++ b/kpconv_torch/io/las.py
@@ -11,14 +11,16 @@ def read_las_laz(filepath):
     filepath: path to a 3D points file with .laz or .las format
 
     Colors are original encoded on 2 bytes
-    (cf. https://www.asprs.org/a/society/committees/standards/asprs_las_spec_v13.pdf), that is on a uint16.
-    They are converted (divided by 256) when the las or the laz file is read by this function.
+    (cf. https://www.asprs.org/a/society/committees/standards/asprs_las_spec_v13.pdf), that is on a
+    uint16. They are converted (divided by 256) when the las or the laz file is read by this
+    function.
 
     Returns
     -------
     points: 2D np.array with type float32
     colors: 2D np.array with type uint8
     labels: 1D np.array with type int32
+
     """
     data = laspy.read(filepath)
     points = np.vstack([data.x, data.y, data.z]).transpose().astype(np.float32)
@@ -62,7 +64,8 @@ def write_las(filepath, points, colors=None, labels=None):
         las.z = points[:, 2]
     else:
         raise TypeError(
-            f"Error while writing file {filepath}: points should be a float32 array, not {colors.dtype}"
+            f"Error while writing file {filepath}: "
+            f"points should be a float32 array, not {colors.dtype}"
         )
     if colors.dtype == np.dtype(np.uint8):
         las.red = colors[:, 0] * 256

--- a/kpconv_torch/models/blocks.py
+++ b/kpconv_torch/models/blocks.py
@@ -9,8 +9,8 @@ from kpconv_torch.kernels.kernel_points import load_kernels
 
 
 def gather(x, idx, method=2):
-    """
-    implementation of a custom gather operation for faster backwards.
+    """Implementation of a custom gather operation for faster backwards.
+
     :param x: input with shape [N, D_1, ... D_d]
     :param idx: indexing with shape [n_1, ..., n_m]
     :param method: Choice of the method
@@ -43,8 +43,8 @@ def gather(x, idx, method=2):
 
 
 def radius_gaussian(sq_r, sig, eps=1e-9):
-    """
-    Compute a radius gaussian (gaussian of distance)
+    """Compute a radius gaussian (gaussian of distance).
+
     :param sq_r: input radiuses [dn, ..., d1, d0]
     :param sig: extents of gaussians [d1, d0] or [d0] or float
     :return: gaussian of sq_r [dn, ..., d1, d0]
@@ -53,11 +53,13 @@ def radius_gaussian(sq_r, sig, eps=1e-9):
 
 
 def closest_pool(x, inds):
-    """
-    Pools features from the closest neighbors. WARNING: this function assumes the neighbors are ordered.
+    """Pools features from the closest neighbors. WARNING: this function assumes the neighbors are
+    ordered.
+
     :param x: [n1, d] features matrix
     :param inds: [n2, max_num] Only the first column is used for pooling
     :return: [n2, d] pooled features matrix
+
     """
 
     # Add a last row with minimum features for shadow pools
@@ -68,8 +70,8 @@ def closest_pool(x, inds):
 
 
 def max_pool(x, inds):
-    """
-    Pools features with the maximum values.
+    """Pools features with the maximum values.
+
     :param x: [n1, d] features matrix
     :param inds: [n2, max_num] pooling indices
     :return: [n2, d] pooled features matrix
@@ -131,19 +133,24 @@ class KPConv(nn.Module):
         deformable=False,
         modulated=False,
     ):
-        """
-        Initialize parameters for KPConvDeformable.
+        """Initialize parameters for KPConvDeformable.
+
         :param kernel_size: Number of kernel points.
         :param p_dim: dimension of the point space.
         :param in_channels: dimension of input features.
         :param out_channels: dimension of output features.
         :param KP_extent: influence radius of each kernel point.
-        :param radius: radius used for kernel point init. Even for deformable, use the config.conv_radius
-        :param fixed_kernel_points: fix position of certain kernel points ('none', 'center' or 'verticals').
-        :param KP_influence: influence function of the kernel points ('constant', 'linear', 'gaussian').
-        :param aggregation_mode: choose to sum influences, or only keep the closest ('closest', 'sum').
+        :param radius: radius used for kernel point init. Even for deformable, use the
+        config.conv_radius
+        :param fixed_kernel_points: fix position of certain kernel points ('none', 'center' or
+        'verticals').
+        :param KP_influence: influence function of the kernel points ('constant', 'linear',
+        'gaussian').
+        :param aggregation_mode: choose to sum influences, or only keep the closest ('closest',
+        'sum').
         :param deformable: choose deformable or not
         :param modulated: choose if kernel weights are modulated in addition to deformed
+
         """
         super().__init__()
 
@@ -160,7 +167,8 @@ class KPConv(nn.Module):
         self.deformable = deformable
         self.modulated = modulated
 
-        # Running variable containing deformed KP distance to input points. (used in regularization loss)
+        # Running variable containing deformed KP distance to input points. (used in regularization
+        # loss)
         self.min_d2 = None
         self.deformed_KP = None
         self.offset_features = None
@@ -299,7 +307,8 @@ class KPConv(nn.Module):
             # New value of max neighbors
             new_max_neighb = torch.max(torch.sum(in_range, dim=1))
 
-            # For each row of neighbors, indices of the ones that are in range [n_points, new_max_neighb]
+            # For each row of neighbors, indices of the ones that are in range [n_points,
+            # new_max_neighb]
             neighb_row_bool, neighb_row_inds = torch.topk(in_range, new_max_neighb.item(), dim=1)
 
             # Gather new neighbor indices [n_points, new_max_neighb]
@@ -420,8 +429,9 @@ def block_decider(block_name, radius, in_dim, out_dim, layer_ind, config):
 
 class BatchNormBlock(nn.Module):
     def __init__(self, in_dim, use_bn, bn_momentum):
-        """Initialize a batch normalization block. If network does not use batch normalization, replace
-        with biases.
+        """Initialize a batch normalization block.
+
+        If network does not use batch normalization, replace with biases.
 
         :param in_dim: dimension input features
         :param use_bn: boolean indicating if we use Batch Norm

--- a/kpconv_torch/train.py
+++ b/kpconv_torch/train.py
@@ -212,11 +212,6 @@ def train(datapath: Path, chosen_log: Path, output_dir: Path, dataset: str) -> N
     training_sampler.calibration(training_loader, verbose=True)
     test_sampler.calibration(test_loader, verbose=True)
 
-    # Optional debug functions
-    # debug_timing(training_dataset, training_loader)
-    # debug_timing(test_dataset, test_loader)
-    # debug_upsampling(training_dataset, training_loader)
-
     print("\nModel Preparation")
     print("*****************")
 

--- a/kpconv_torch/utils/config.py
+++ b/kpconv_torch/utils/config.py
@@ -87,7 +87,8 @@ class Config:
     # Radius of convolution in "number grid cell". (2.5 is the standard value)
     conv_radius = 2.5
 
-    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can spread out
+    # Radius of deformable convolution in "number grid cell". Larger so that deformed kernel can
+    # spread out
     deform_radius = 5.0
 
     # Kernel point influence radius

--- a/kpconv_torch/visualize.py
+++ b/kpconv_torch/visualize.py
@@ -64,7 +64,8 @@ def visualize(datapath: Path, chosen_log: Path) -> None:
     # Choose the index of the checkpoint to load OR None if you want to load the current checkpoint
     chkp_idx = None
 
-    # Eventually you can choose which feature is visualized (index of the deform convolution in the network)
+    # Eventually you can choose which feature is visualized (index of the deform convolution in the
+    # network)
     deform_idx = 0
 
     # Deal with 'last_XXX' choices

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ extra_requirements = {
 setup(
     name="kpconv_torch",
     version=find_version(),
-    description="An implementation of KPConv algorithm with PyTorch (initial credit to Hugues Thomas)",
+    description=(
+        "An implementation of KPConv algorithm with PyTorch (initial credit to Hugues Thomas)"
+    ),
     long_description=readme,
     author="Raphaël Delhome",
     author_email="raphael.delhome@oslandia.com",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,10 @@ from kpconv_torch.cli.__main__ import valid_dataset, valid_dir
 
 
 def test_valid_dataset():
-    """valid_dataset returns the dataset itself if it is supported, otherwise it raises an argparse error."""
+    """If the dataset is supported, valid_dataset returns it, otherwise it raises an argparse
+    error.
+
+    """
     assert valid_dataset("S3DIS") == "S3DIS"
     with pytest.raises(ArgumentTypeError):
         valid_dataset("wrong_dataset")


### PR DESCRIPTION
Fix all E800 (commented code) and B950 (line-length) flake8 alerts, and unactivate the check on C901 (too complex function) so that further development won't be blocked on complex modules.

Disclaimer: too complex function should ideally be simplified... That's on ongoing effort to do.

Draft: merge #42 first, as a lot of modules are impacted and the PR fixes things... (By the way, this branch is starting from the #42 branch)