### PR TITLE
Optimize ram consumption during inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tests/fixtures/example_with_classification.*
 tests/fixtures/example_without_classification.*
 tests/fixtures/example.las
 tests/fixtures/example.xyz
+tests/fixtures/example_from_generator.ply
 tests/trained_models/
 tests/fixtures/S3DIS/calibration/
 tests/fixtures/S3DIS/input_0.030/

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -842,6 +842,13 @@ class S3DISDataset(PointCloudDataset):
             raise OSError(f"Unsupported input file extension ({file_extension}).")
         return points, colors, labels
 
+    def generate_projected_point_batches(self, file_idx, file_path, step=5_000_000):
+        points, _, _ = self.read_input(file_path, xyz_only=True)
+        nb_points = points.shape[0]
+        for idx in range(0, nb_points, step):
+            max_idx = min(idx + step, nb_points)
+            yield points[idx:max_idx, :], self.test_proj[file_idx][idx:max_idx]
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 #

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -826,18 +826,18 @@ class S3DISDataset(PointCloudDataset):
         points, _, _ = self.read_input(file_path)
         return points
 
-    def read_input(self, filepath):
+    def read_input(self, filepath, xyz_only=False):
         """Read all the input files that belong to the dataset
 
         PLY files are read by training and testing commands.
         """
         file_extension = Path(filepath).suffix
         if file_extension == ".ply":
-            points, colors, labels = read_ply(filepath)
+            points, colors, labels = read_ply(filepath, xyz_only=xyz_only)
         elif file_extension == ".xyz":
-            points, colors, labels = read_xyz(filepath)
+            points, colors, labels = read_xyz(filepath, xyz_only=xyz_only)
         elif file_extension == ".las" or file_extension == ".laz":
-            points, colors, labels = read_las_laz(filepath)
+            points, colors, labels = read_las_laz(filepath, xyz_only=xyz_only)
         else:
             raise OSError(f"Unsupported input file extension ({file_extension}).")
         return points, colors, labels

--- a/kpconv_torch/datasets/S3DIS.py
+++ b/kpconv_torch/datasets/S3DIS.py
@@ -68,7 +68,7 @@ class S3DISDataset(PointCloudDataset):
         # Data folder management
         if self.task == "test" and infered_file is not None:
             # Inference case: a S3DIS dataset is built with the infered file
-            self.cloud_names = [infered_file]
+            self.cloud_names = [infered_file.name]
         else:
             # Any other case: the S3DIS dataset is built with the S3DIS original data
             if self.task == "all":
@@ -86,7 +86,7 @@ class S3DISDataset(PointCloudDataset):
             ]
         self.files = [
             (
-                cloud_name
+                infered_file
                 if self.task == "test" and infered_file is not None
                 else self.train_files_path / (cloud_name + ".ply")
             )

--- a/kpconv_torch/io/las.py
+++ b/kpconv_torch/io/las.py
@@ -40,9 +40,9 @@ def read_las_laz(filepath, xyz_only=False):
     else:
         colors = np.zeros((points.shape[0], 3))
     if "classification" in dims:
-        labels = np.array(data.classification).astype(np.int32)
+        labels = np.array(data.classification).astype(np.int8)
     else:
-        labels = np.zeros(points.shape[0])
+        labels = np.zeros(points.shape[0], dtype=np.int8)
 
     return points, colors, labels
 

--- a/kpconv_torch/io/las.py
+++ b/kpconv_torch/io/las.py
@@ -27,9 +27,13 @@ def read_las_laz(filepath, xyz_only=False):
     if xyz_only:
         return points, None, None
     dims = list(data.point_format.dimension_names)
+    colorfactor = 256
+    if data.red.max() <= 255:
+        print("The color data seems to be wrongly encoded and defined on 1 byte.")
+        colorfactor = 1
     if "red" in dims and "blue" in dims and "green" in dims:
         colors = (
-            np.vstack([data.red / 256, data.green / 256, data.blue / 256])
+            np.vstack([data.red / colorfactor, data.green / colorfactor, data.blue / colorfactor])
             .transpose()
             .astype(np.uint8)
         )

--- a/kpconv_torch/io/las.py
+++ b/kpconv_torch/io/las.py
@@ -6,20 +6,15 @@ def read_las_laz(filepath, xyz_only=False):
     """Takes a file path pointing on a 3D point .las or .laz file and returns the points,
     the associated colors and the associated classes.
 
-    Parameters
-    ----------
-    filepath: path to a 3D points file with .laz or .las format
+    :param filepath: path to a 3D points file with .laz or .las format. Colors are original encoded
+    on 2 bytes (cf. https://www.asprs.org/a/society/committees/standards/asprs_las_spec_v13.pdf),
+    that is on a uint16. They are converted (divided by 256) when the las or the laz file is read
+    by this function.
+    :type filepath: str
 
-    Colors are original encoded on 2 bytes
-    (cf. https://www.asprs.org/a/society/committees/standards/asprs_las_spec_v13.pdf), that is on a
-    uint16. They are converted (divided by 256) when the las or the laz file is read by this
-    function.
-
-    Returns
-    -------
-    points: 2D np.array with type float32
-    colors: 2D np.array with type uint8
-    labels: 1D np.array with type int32
+    :returns: 2D np.array with type float32, 2D np.array with type uint8, 1D np.array with type
+    int32
+    :rtype: tuple
 
     """
     data = laspy.read(filepath)
@@ -49,15 +44,24 @@ def read_las_laz(filepath, xyz_only=False):
 
 def write_las(filepath, points, colors=None, labels=None):
     """Creates a .las file from a 3D point cloud.
-    Parameters
-    ----------
-    filepath: path to the .las file
-    points: 2D np.array with type float32
-    colors: 2D np.array with type uint8 or uint16
-    labels: 1D np.array with type int32
 
     Uses a point_format = 7 (cf. https://pythonhosted.org/laspy/tut_background.html)
     Warning: laspy does not have support for writing files in the .laz format.
+
+    :param filepath: path to the .las file
+    :type filepath: str
+    :param points: 2D np.array with type float32
+    :type points: np.array
+    :param colors: 2D np.array with type uint8 or uint16
+    :type colors: np.array
+    :param labels: 1D np.array with type int32
+    :type labels: np.array
+
+    :raises TypeError: Wrong type for points, colors or classification
+
+    :returns: True if the file is correctly written
+    :rtype: boolean
+
     """
     if colors is None:
         colors = np.zeros(points.shape[0], 3).astype(np.uint8)

--- a/kpconv_torch/io/las.py
+++ b/kpconv_torch/io/las.py
@@ -2,7 +2,7 @@ import laspy
 import numpy as np
 
 
-def read_las_laz(filepath):
+def read_las_laz(filepath, xyz_only=False):
     """Takes a file path pointing on a 3D point .las or .laz file and returns the points,
     the associated colors and the associated classes.
 
@@ -24,6 +24,8 @@ def read_las_laz(filepath):
     """
     data = laspy.read(filepath)
     points = np.vstack([data.x, data.y, data.z]).transpose().astype(np.float32)
+    if xyz_only:
+        return points, None, None
     dims = list(data.point_format.dimension_names)
     if "red" in dims and "blue" in dims and "green" in dims:
         colors = (

--- a/kpconv_torch/io/ply.py
+++ b/kpconv_torch/io/ply.py
@@ -196,7 +196,7 @@ def read_ply(filepath, triangular_mesh=False, xyz_only=False):
     return points, colors, labels
 
 
-def write_ply(filename, field_list, field_names, triangular_faces=None):
+def write_ply(filename, field_list, field_names, triangular_faces=None, write_header=True):
     """
     Write ".ply" files
 
@@ -259,26 +259,27 @@ def write_ply(filename, field_list, field_names, triangular_faces=None):
     if not filename.endswith(".ply"):
         filename += ".ply"
 
-    # open in text mode to write the header
-    with open(filename, "w") as plyfile:
+    if write_header:
+        # open in text mode to write the header
+        with open(filename, "w") as plyfile:
 
-        # First magical word and encoding format
-        header = ["ply", "format binary_" + sys.byteorder + "_endian 1.0"]
+            # First magical word and encoding format
+            header = ["ply", "format binary_" + sys.byteorder + "_endian 1.0"]
 
-        # Points properties description
-        header.extend(header_properties(field_list, field_names))
+            # Points properties description
+            header.extend(header_properties(field_list, field_names))
 
-        # Add faces if needded
-        if triangular_faces is not None:
-            header.append(f"element face {triangular_faces.shape[0]:d}")
-            header.append("property list uchar int vertex_indices")
+            # Add faces if needded
+            if triangular_faces is not None:
+                header.append(f"element face {triangular_faces.shape[0]:d}")
+                header.append("property list uchar int vertex_indices")
 
-        # End of header
-        header.append("end_header")
+            # End of header
+            header.append("end_header")
 
-        # Write all lines
-        for line in header:
-            plyfile.write("%s\n" % line)
+            # Write all lines
+            for line in header:
+                plyfile.write("%s\n" % line)
 
     # open in binary/append to use tofile
     with open(filename, "ab") as plyfile:

--- a/kpconv_torch/io/ply.py
+++ b/kpconv_torch/io/ply.py
@@ -191,7 +191,7 @@ def read_ply(filepath, triangular_mesh=False, xyz_only=False):
         if "classification" in fields:
             labels = data["classification"]
         else:
-            labels = np.zeros((points.shape[0]), dtype=np.int32)
+            labels = np.zeros((points.shape[0]), dtype=np.int8)
 
     return points, colors, labels
 

--- a/kpconv_torch/io/ply.py
+++ b/kpconv_torch/io/ply.py
@@ -120,7 +120,7 @@ def parse_mesh_header(plyfile, ext):
     return num_points, num_faces, vertex_properties
 
 
-def read_ply(filepath, triangular_mesh=False):
+def read_ply(filepath, triangular_mesh=False, xyz_only=False):
     """Takes a file path pointing on a 3D point .ply file and returns the points,
     the associated colors and the associated classes.
 
@@ -180,6 +180,8 @@ def read_ply(filepath, triangular_mesh=False):
 
         fields = [p[0] for p in properties]
         points = np.vstack((data["x"], data["y"], data["z"])).transpose().astype(np.float32)
+        if xyz_only:
+            return points, None, None
         if "red" in fields and "green" in fields and "blue" in fields:
             colors = (
                 np.vstack((data["red"], data["green"], data["blue"])).transpose().astype(np.uint8)

--- a/kpconv_torch/io/ply.py
+++ b/kpconv_torch/io/ply.py
@@ -29,14 +29,14 @@ ply_dtypes = {
 def describe_element(name, df):
     """Takes the columns of the dataframe and builds a ply-like description
 
-    Parameters
-    ----------
-    name: str
-    df: pandas DataFrame
+    :param name: Name of the element
+    :type name: str
+    :param df:
+    :type df: pandas.DataFrame
 
-    Returns
-    -------
-    element: list[str]
+    :return: elements
+    :rtype: list[str]
+
     """
     property_formats = {"f": "float", "u": "uchar", "i": "int"}
     element = ["element " + name + " " + str(len(df))]
@@ -109,17 +109,14 @@ def read_ply(filepath, triangular_mesh=False, xyz_only=False):
     """Takes a file path pointing on a 3D point .ply file and returns the points,
     the associated colors and the associated classes.
 
-    Parameters
-    ----------
-    filepath: path to a 3D points file with .ply format
+    :param filepath: path to a 3D points file with .ply format
+    :type filepath: str
 
-    Returns
-    -------
-    points: 2D np.array with type float32
-    colors: 2D np.array with type uint8
-    labels: 1D np.array with type int32
+    :returns: 2D np.array with type float32, 2D np.array with type uint8, 1D np.array with type
+    int32
+    :rtype: tuple
+
     """
-
     with open(filepath, "rb") as plyfile:
         # Check if the file start with ply
         if b"ply" not in plyfile.readline():
@@ -278,35 +275,29 @@ def write_ply_data(filename, field_list, field_names, triangular_faces=None):
 
 
 def write_ply(filename, field_list, field_names, triangular_faces=None):
-    """
-    Write ".ply" files
+    """Write ".ply" files
 
-    Parameters
-    ----------
-    filename : string
-        the name of the file to which the data is saved. A '.ply' extension will be appended to the
-        file name if it does no already have one.
+    :param filename: the name of the file to which the data is saved. A '.ply' extension will be
+    appended to the file name if it does no already have one.
+    :type filename: str
+    :param field_list: the fields to be saved in the ply file. Either a numpy array, a list of
+    numpy arrays or a tuple of numpy arrays. Each 1D numpy array and each column of 2D numpy arrays
+    are considered as one field.
+    :type field_list: list|tuple|numpy.array
+    :param field_names: the name of each fields as a list of strings. Has to be the same length as
+        the number of fields.
+    :type field_names: list
 
-    field_list : list, tuple, numpy array
-        the fields to be saved in the ply file. Either a numpy array, a list of numpy arrays or a
-        tuple of numpy arrays. Each 1D numpy array and each column of 2D numpy arrays are considered
-        as one field.
+    :Example:
 
-    field_names : list
-        the name of each fields as a list of strings. Has to be the same length as the number of
-        fields.
-
-    Examples
-    --------
     >>> points = np.random.rand(10, 3)
     >>> write_ply('example1.ply', points, ['x', 'y', 'z'])
-
     >>> values = np.random.randint(2, size=10)
     >>> write_ply('example2.ply', [points, values], ['x', 'y', 'z', 'values'])
-
     >>> colors = np.random.randint(255, size=(10,3), dtype=np.uint8)
     >>> field_names = ['x', 'y', 'z', 'red', 'green', 'blue', 'classification']
     >>> write_ply('example3.ply', [points, colors, values], field_names)
+
     """
     # Format list input to the right form
     field_list = (

--- a/kpconv_torch/io/xyz.py
+++ b/kpconv_torch/io/xyz.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def read_xyz(filepath):
+def read_xyz(filepath, xyz_only=False):
     """Takes a file path pointing on a 3D point .xyz (text) file and returns the points,
     the associated colors and the associated classes.
 
@@ -17,6 +17,8 @@ def read_xyz(filepath):
     """
     data = np.loadtxt(filepath, delimiter=" ")
     points = data[:, :3].astype(np.float32)
+    if xyz_only:
+        return points, None, None
     if data.shape[1] >= 6:
         colors = data[:, 3:6].astype(np.uint8)
     else:

--- a/kpconv_torch/io/xyz.py
+++ b/kpconv_torch/io/xyz.py
@@ -5,15 +5,13 @@ def read_xyz(filepath, xyz_only=False):
     """Takes a file path pointing on a 3D point .xyz (text) file and returns the points,
     the associated colors and the associated classes.
 
-    Parameters
-    ----------
-    filepath: path to a 3D points file with .xyz
+    :param filepath: path to a 3D points file with .xyz
+    :type filepath: str
 
-    Returns
-    -------
-    points: 2D np.array with type float32
-    colors: 2D np.array with type uint8
-    labels: 1D np.array with type int32
+    :returns: 2D np.array with type float32, 2D np.array with type uint8, 1D np.array with type
+    int32
+    :rtype: tuple
+
     """
     data = np.loadtxt(filepath, delimiter=" ")
     points = data[:, :3].astype(np.float32)
@@ -33,13 +31,19 @@ def read_xyz(filepath, xyz_only=False):
 
 def write_xyz(filepath, points, colors=None, labels=None):
     """Creates a .xyz file from a 3D point cloud.
-    Parameters
-    ----------
-    filepath : pathlib.Path
-        Path where to save the data
-    points: 2D np.array with type float32 to save
-    colors: 2D np.array with type uint8 to save
-    labels: 1D np.array with type int32 to save
+
+    :param filepath: path to the .las file
+    :type filepath: str
+    :param points: 2D np.array with type float32
+    :type points: np.array
+    :param colors: 2D np.array with type uint8 or uint16
+    :type colors: np.array
+    :param labels: 1D np.array with type int32
+    :type labels: np.array
+
+    :returns: True if the file is correctly written
+    :rtype: boolean
+
     """
     if colors is None:
         colors = np.zeros(points.shape[0], 3).astype(np.uint8)

--- a/kpconv_torch/io/xyz.py
+++ b/kpconv_torch/io/xyz.py
@@ -24,9 +24,9 @@ def read_xyz(filepath, xyz_only=False):
     else:
         colors = colors.shape[0] > 0
     if data.shape[1] == 4:
-        labels = np.squeeze(data[:, 3]).astype(np.int32)
+        labels = np.squeeze(data[:, 3]).astype(np.int8)
     if data.shape[1] == 7:
-        labels = np.squeeze(data[:, 6]).astype(np.int32)
+        labels = np.squeeze(data[:, 6]).astype(np.int8)
 
     return points, colors, labels
 

--- a/kpconv_torch/utils/metrics.py
+++ b/kpconv_torch/utils/metrics.py
@@ -23,10 +23,12 @@ def fast_confusion(true, pred, label_values=None):
                 len(pred.shape)
             )
         )
-    if true.dtype not in [np.int32, np.int64]:
-        raise ValueError(f"Truth values are {true.dtype} instead of int32 or int64")
-    if pred.dtype not in [np.int32, np.int64]:
-        raise ValueError(f"Prediction values are {pred.dtype} instead of int32 or int64")
+    if true.dtype not in [np.int8, np.int16, np.int32, np.int64]:
+        raise ValueError(f"Truth values are {true.dtype} instead of int8, int16, int32 or int64")
+    if pred.dtype not in [np.int8, np.int16, np.int32, np.int64]:
+        raise ValueError(
+            f"Prediction values are {pred.dtype} instead of int8, int16, int32 or int64"
+        )
     true = true.astype(np.int32)
     pred = pred.astype(np.int32)
 
@@ -36,8 +38,10 @@ def fast_confusion(true, pred, label_values=None):
         label_values = np.unique(np.hstack((true, pred)))
     else:
         # Ensure they are good if given
-        if label_values.dtype not in [np.int32, np.int64]:
-            raise ValueError(f"label values are {label_values.dtype} instead of int32 or int64")
+        if label_values.dtype not in [np.int8, np.int16, np.int32, np.int64]:
+            raise ValueError(
+                f"label values are {label_values.dtype} instead of int8, int16, int32 or int64"
+            )
         if len(np.unique(label_values)) < len(label_values):
             raise ValueError("Given labels are not unique")
 

--- a/kpconv_torch/utils/tester.py
+++ b/kpconv_torch/utils/tester.py
@@ -316,7 +316,7 @@ class ModelTester:
 
                         # Predicted labels
                         preds = test_loader.dataset.label_values[np.argmax(probs, axis=1)].astype(
-                            np.int32
+                            np.int8
                         )
 
                         # Targets

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -43,6 +43,27 @@ def test_write_ply_without_classification(fixture_path, points_array, colors_arr
 
 
 @mark.dependency()
+def test_write_ply_generator(fixture_path, points_array):
+    example_filepath = fixture_path / "example_from_generator.ply"
+    points = np.concatenate([points_array, points_array])
+
+    def point_gen(points):
+        """Produce a dummy generator for testing purpose, with two points per iteration."""
+        for p in range(0, points.shape[0], 2):
+            yield points[p : p + 2]
+
+    res = ply.write_ply_from_generator(
+        str(example_filepath),
+        [point_gen(points)],
+        ["x", "y", "z"],
+        nb_points=points.shape[0],
+    )
+    assert res and example_filepath.exists()
+    points_1, _, _ = ply.read_ply(str(example_filepath))
+    assert points_1.shape == points.shape
+
+
+@mark.dependency()
 def test_write_las_with_classification(
     fixture_path, points_array, colors_array, classification_array
 ):


### PR DESCRIPTION
Running inference on a big point clouds (more than 200M points) does not fit a 30Gb-RAM server, on the current state of the code.

This branch proposes several improvements in order to be able to apply trained models on large files:

- Consider classification values as `np.int8` instead of `np.int32` (1 byte instead of 4 for each value). 
- Read only xyz coordinates during the writing process: we want to write xyz coordinates in some results file, then read only this information, and not the color and classification results.
- Last but not the least: refactor the main inference function related to cloud segmentation, and introduce a batching procedure to process smaller sets of points through a generator, i.e. get batch of 5M points, recover the corresponding predictions and write outputs in append mode.

Related issue: #51